### PR TITLE
Build Seth docs

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -86,8 +86,8 @@ node ('master') {
         }
 
         stage ("Build documentation") {
-            sh 'docker build . -f ci/sawtooth-build-docs -t sawtooth-build-docs:$ISOLATION_ID'
-            sh 'docker run --rm -v $(pwd):/project/sawtooth-core sawtooth-build-docs:$ISOLATION_ID'
+            sh 'docker build . -f sawtooth-build-docs -t sawtooth-build-docs:$ISOLATION_ID'
+            sh 'docker run --rm -v $(pwd):/project/sawtooth-seth sawtooth-build-docs:$ISOLATION_ID'
         }
 
         stage("Archive Build artifacts") {

--- a/bin/generate_cli_output
+++ b/bin/generate_cli_output
@@ -1,0 +1,36 @@
+#!/bin/bash
+
+if [ ! -e source/conf.py ]; then
+    echo "Must be run from the sawtooth-core repo docs directory." 1>&2
+    exit 1
+fi
+
+function save_usage() {
+   safe_string=$(echo "$*" | sed -e 's/[^A-Za-z0-9-]/_/g')
+   filename="source/cli/output/${safe_string}_usage.out"
+   if ! output=$("$@" -h); then
+       exit 1
+   fi
+   echo "Generating: $filename"
+   echo "$output" > "$filename"
+}
+
+export PATH=$PATH:$(pwd)/../bin
+mkdir -p source/cli/output
+
+save_usage seth
+save_usage seth init
+save_usage seth show
+save_usage seth account
+save_usage seth account import
+save_usage seth account list
+save_usage seth account create
+save_usage seth contract
+save_usage seth contract call
+save_usage seth contract create
+save_usage seth permissions
+save_usage seth permissions set
+
+save_usage seth-tp
+
+save_usage seth-rpc

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -20,7 +20,7 @@ ALLSPHINXOPTS   = -W -d $(BUILDDIR)/doctrees $(PAPEROPT_$(PAPER)) $(SPHINXOPTS) 
 # the i18n builder cannot share the environment and doctrees with the others
 I18NSPHINXOPTS  = $(PAPEROPT_$(PAPER)) $(SPHINXOPTS) source
 
-.PHONY: help clean templates html dirhtml singlehtml pickle json htmlhelp qthelp devhelp epub latex latexpdf text man changes linkcheck doctest coverage gettext cli
+.PHONY: help clean html dirhtml singlehtml pickle json htmlhelp qthelp devhelp epub latex latexpdf text man changes linkcheck doctest coverage gettext cli
 
 help:
 	@echo "Please use \`make <target>' where <target> is one of"
@@ -52,47 +52,42 @@ help:
 clean:
 	rm -rf $(BUILDDIR)/* source/cli/output/*.out
 
-templates:
-	@mkdir -p source/_autogen
-	@../bin/make_templated_docs
-
 cli:
 	../bin/generate_cli_output
 
-html: templates cli
+html: cli
 	@mkdir -p source/_static
 	$(SPHINXBUILD) -b html $(ALLSPHINXOPTS) $(BUILDDIR)/html
 	@echo
 	@echo "Build finished. The HTML pages are in $(BUILDDIR)/html."
-	@cp ../docker/compose/sawtooth-default.yaml $(BUILDDIR)/html/app_developers_guide/sawtooth-default.yaml
 
-dirhtml: templates cli
+dirhtml: cli
 	$(SPHINXBUILD) -b dirhtml $(ALLSPHINXOPTS) $(BUILDDIR)/dirhtml
 	@echo
 	@echo "Build finished. The HTML pages are in $(BUILDDIR)/dirhtml."
 
-singlehtml: templates cli
+singlehtml: cli
 	$(SPHINXBUILD) -b singlehtml $(ALLSPHINXOPTS) $(BUILDDIR)/singlehtml
 	@echo
 	@echo "Build finished. The HTML page is in $(BUILDDIR)/singlehtml."
 
-pickle: templates cli
+pickle: cli
 	$(SPHINXBUILD) -b pickle $(ALLSPHINXOPTS) $(BUILDDIR)/pickle
 	@echo
 	@echo "Build finished; now you can process the pickle files."
 
-json: templates cli
+json: cli
 	$(SPHINXBUILD) -b json $(ALLSPHINXOPTS) $(BUILDDIR)/json
 	@echo
 	@echo "Build finished; now you can process the JSON files."
 
-htmlhelp: templates cli
+htmlhelp: cli
 	$(SPHINXBUILD) -b htmlhelp $(ALLSPHINXOPTS) $(BUILDDIR)/htmlhelp
 	@echo
 	@echo "Build finished; now you can run HTML Help Workshop with the" \
 	      ".hhp project file in $(BUILDDIR)/htmlhelp."
 
-qthelp: templates cli
+qthelp: cli
 	$(SPHINXBUILD) -b qthelp $(ALLSPHINXOPTS) $(BUILDDIR)/qthelp
 	@echo
 	@echo "Build finished; now you can run "qcollectiongenerator" with the" \
@@ -101,7 +96,7 @@ qthelp: templates cli
 	@echo "To view the help file:"
 	@echo "# assistant -collectionFile $(BUILDDIR)/qthelp/IntelMaidenLane.qhc"
 
-applehelp: templates cli
+applehelp: cli
 	$(SPHINXBUILD) -b applehelp $(ALLSPHINXOPTS) $(BUILDDIR)/applehelp
 	@echo
 	@echo "Build finished. The help book is in $(BUILDDIR)/applehelp."
@@ -109,7 +104,7 @@ applehelp: templates cli
 	      "~/Library/Documentation/Help or install it in your application" \
 	      "bundle."
 
-devhelp: templates cli
+devhelp: cli
 	$(SPHINXBUILD) -b devhelp $(ALLSPHINXOPTS) $(BUILDDIR)/devhelp
 	@echo
 	@echo "Build finished."
@@ -118,86 +113,86 @@ devhelp: templates cli
 	@echo "# ln -s $(BUILDDIR)/devhelp $$HOME/.local/share/devhelp/IntelMaidenLane"
 	@echo "# devhelp"
 
-epub: templates cli
+epub: cli
 	$(SPHINXBUILD) -b epub $(ALLSPHINXOPTS) $(BUILDDIR)/epub
 	@echo
 	@echo "Build finished. The epub file is in $(BUILDDIR)/epub."
 
-latex: templates cli
+latex: cli
 	$(SPHINXBUILD) -b latex $(ALLSPHINXOPTS) $(BUILDDIR)/latex
 	@echo
 	@echo "Build finished; the LaTeX files are in $(BUILDDIR)/latex."
 	@echo "Run \`make' in that directory to run these through (pdf)latex" \
 	      "(use \`make latexpdf' here to do that automatically)."
 
-latexpdf: templates cli
+latexpdf: cli
 	@mkdir -p source/_static
 	$(SPHINXBUILD) -b latex $(ALLSPHINXOPTS) $(BUILDDIR)/latex
 	@echo "Running LaTeX files through pdflatex..."
 	$(MAKE) -C $(BUILDDIR)/latex all-pdf
 	@echo "pdflatex finished; the PDF files are in $(BUILDDIR)/latex."
 
-latexpdfja: templates cli
+latexpdfja: cli
 	$(SPHINXBUILD) -b latex $(ALLSPHINXOPTS) $(BUILDDIR)/latex
 	@echo "Running LaTeX files through platex and dvipdfmx..."
 	$(MAKE) -C $(BUILDDIR)/latex all-pdf-ja
 	@echo "pdflatex finished; the PDF files are in $(BUILDDIR)/latex."
 
-text: templates cli
+text: cli
 	$(SPHINXBUILD) -b text $(ALLSPHINXOPTS) $(BUILDDIR)/text
 	@echo
 	@echo "Build finished. The text files are in $(BUILDDIR)/text."
 
-man: templates cli
+man: cli
 	$(SPHINXBUILD) -b man $(ALLSPHINXOPTS) $(BUILDDIR)/man
 	@echo
 	@echo "Build finished. The manual pages are in $(BUILDDIR)/man."
 
-texinfo: templates cli
+texinfo: cli
 	$(SPHINXBUILD) -b texinfo $(ALLSPHINXOPTS) $(BUILDDIR)/texinfo
 	@echo
 	@echo "Build finished. The Texinfo files are in $(BUILDDIR)/texinfo."
 	@echo "Run \`make' in that directory to run these through makeinfo" \
 	      "(use \`make info' here to do that automatically)."
 
-info: templates cli
+info: cli
 	$(SPHINXBUILD) -b texinfo $(ALLSPHINXOPTS) $(BUILDDIR)/texinfo
 	@echo "Running Texinfo files through makeinfo..."
 	make -C $(BUILDDIR)/texinfo info
 	@echo "makeinfo finished; the Info files are in $(BUILDDIR)/texinfo."
 
-gettext: templates cli
+gettext: cli
 	$(SPHINXBUILD) -b gettext $(I18NSPHINXOPTS) $(BUILDDIR)/locale
 	@echo
 	@echo "Build finished. The message catalogs are in $(BUILDDIR)/locale."
 
-changes: templates cli
+changes: cli
 	$(SPHINXBUILD) -b changes $(ALLSPHINXOPTS) $(BUILDDIR)/changes
 	@echo
 	@echo "The overview file is in $(BUILDDIR)/changes."
 
-linkcheck: templates cli
+linkcheck: cli
 	$(SPHINXBUILD) -b linkcheck $(ALLSPHINXOPTS) $(BUILDDIR)/linkcheck
 	@echo
 	@echo "Link check complete; look for any errors in the above output " \
 	      "or in $(BUILDDIR)/linkcheck/output.txt."
 
-doctest: templates cli
+doctest: cli
 	$(SPHINXBUILD) -b doctest $(ALLSPHINXOPTS) $(BUILDDIR)/doctest
 	@echo "Testing of doctests in the sources finished, look at the " \
 	      "results in $(BUILDDIR)/doctest/output.txt."
 
-coverage: templates cli
+coverage: cli
 	$(SPHINXBUILD) -b coverage $(ALLSPHINXOPTS) $(BUILDDIR)/coverage
 	@echo "Testing of coverage in the sources finished, look at the " \
 	      "results in $(BUILDDIR)/coverage/python.txt."
 
-xml: templates cli
+xml: cli
 	$(SPHINXBUILD) -b xml $(ALLSPHINXOPTS) $(BUILDDIR)/xml
 	@echo
 	@echo "Build finished. The XML files are in $(BUILDDIR)/xml."
 
-pseudoxml: templates cli
+pseudoxml: cli
 	$(SPHINXBUILD) -b pseudoxml $(ALLSPHINXOPTS) $(BUILDDIR)/pseudoxml
 	@echo
 	@echo "Build finished. The pseudo-XML files are in $(BUILDDIR)/pseudoxml."

--- a/docs/source/_templates/indexcontent.html
+++ b/docs/source/_templates/indexcontent.html
@@ -1,0 +1,23 @@
+{%- extends "layout.html" %}
+{% set title = 'Overview' %}
+{% block body %}
+
+  <h1>Hyperledger Sawtooth documentation</h1>
+
+  <p><select id="version_switcher"></select></p>
+
+  <p class="biglink"><a class="biglink" href="{{ pathto("introduction") }}">{% trans %}Introduction{% endtrans %}</a><br/>
+    <span class="linkdescr">{% trans %}learn about Hyperledger Sawtooth{% endtrans %}</span></p>
+
+  <p class="biglink"><a class="biglink" href="{{ pathto("seth_developers_guide") }}">{% trans %}Seth Developer's Guide{% endtrans %}</a><br/>
+    <span class="linkdescr">{% trans %}Sawtooth Seth platform code and documentation{% endtrans %}</span></p>
+
+  <p class="biglink"><a class="biglink" href="{{ pathto("community") }}">{% trans %}Community{% endtrans %}</a><br/>
+    <span class="linkdescr">{% trans %}join the conversation{% endtrans %}</span></p>
+
+  <p class="biglink"><a class="biglink" href="{{ pathto("contents") }}">{% trans %}Table of Contents{% endtrans %}</a><br/>
+    <span class="linkdescr">{% trans %}detailed list of documentation sections{% endtrans %}</span></p>
+
+<script src="_static/version_switcher.js">
+
+{% endblock %}

--- a/docs/source/contents.rst
+++ b/docs/source/contents.rst
@@ -5,14 +5,5 @@ Table of Contents
 .. toctree::
 
    introduction.rst
-   architecture.rst
-   app_developers_guide.rst
    seth_developers_guide.rst
-   core_developers_guide.rst
-   sysadmin_guide.rst
-   rest_api.rst
-   cli.rst
-   transaction_family_specifications.rst
-   examples.rst
    community.rst
-   faq.rst

--- a/docs/source/introduction.rst
+++ b/docs/source/introduction.rst
@@ -133,7 +133,7 @@ dev_mode and PoET.
     which simulates the secure instructions. This should make it easier for
     the community to work with the software but also forgoes Byzantine fault
     tolerance.  For more information, see
-    :doc:`PoET 1.0 Specification <../architecture/poet>`.
+    `PoET 1.0 Specification <../architecture/poet>`.
 
 
 Getting Sawtooth

--- a/docs/source/seth_developers_guide/seth_transaction_family_spec.rst
+++ b/docs/source/seth_developers_guide/seth_transaction_family_spec.rst
@@ -455,7 +455,7 @@ Events
 Ethereum defines a set of LOGX for X in [0, 4] instructions that allow contracts
 to log off-chain data. Solidity uses these instructions to implement an event
 subscription system. To make Seth compatible with both, the LOGX instructions
-generate :doc:`Sawtooth Events
+generate `Sawtooth Events
 </architecture/events_and_transactions_receipts>`. Like Seth's transaction
 receipts, these events contain only the data that is available during
 transaction execution.

--- a/sawtooth-build-docs
+++ b/sawtooth-build-docs
@@ -1,0 +1,95 @@
+# Copyright 2017 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ------------------------------------------------------------------------------
+
+# Description:
+#   Builds the environment needed to build the Sawtooth Seth docs
+#   Running the image will put the Sawtooth Seth docs in
+#   sawtooth-seth/docs/build on your local machine.
+#
+# Build:
+#   $ cd sawtooth-seth
+#   $ docker build . -f sawtooth-build-docs -t sawtooth-build-docs
+#
+# Run:
+#   $ cd sawtooth-seth
+#   $ docker run -v $(pwd):/project/sawtooth-seth sawtooth-build-docs
+
+FROM sawtooth-seth
+
+RUN echo "deb http://repo.sawtooth.me/ubuntu/ci xenial universe" >> /etc/apt/sources.list \
+ && apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 8AA7AF1F1091A5FD \
+ && apt-get update \
+ && apt-get install -y -q --allow-downgrades \
+    build-essential \
+    git \
+    libffi-dev \
+    libssl-dev \
+    pep8 \
+    python3-aiodns=1.1.1-1 \
+    python3-aiohttp=1.3.5-1 \
+    python3-async-timeout=1.2.0-1 \
+    python3-bitcoin=1.1.42-1 \
+    python3-cbor \
+    python3-cchardet=2.0a3-1 \
+    python3-chardet=2.3.0-1 \
+    python3-colorlog \
+    python3-cryptography-vectors=1.7.2-1 \
+    python3-cryptography=1.7.2-1 \
+    python3-dev \
+    python3-grpcio-tools=1.1.3-1 \
+    python3-grpcio=1.1.3-1 \
+    python3-lmdb=0.92-1 \
+    python3-multidict=2.1.4-1 \
+    python3-netifaces=0.10.4-0.1build2 \
+    python3-pyformance \
+    python3-pip \
+    python3-protobuf \
+    python3-pycares=2.1.1-1 \
+    python3-pytest-runner=2.6.2-1 \
+    python3-pytest=2.9.0-1 \
+    python3-pytz=2016.10-1 \
+    python3-requests \
+    python3-secp256k1=0.13.2-1 \
+    python3-setuptools-scm=1.15.0-1 \
+    python3-six=1.10.0-1 \
+    python3-toml \
+    python3-yaml \
+    python3-yarl=0.10.0-1 \
+    python3-zmq \
+ && apt-get clean \
+ && rm -rf /var/lib/apt/lists/* \
+ && pip3 install \
+    pylint \
+    bandit
+
+RUN apt-get update && apt-get install -y -q \
+    dvipng \
+    make \
+    sudo \
+    texlive-fonts-recommended \
+    texlive-latex-base \
+    texlive-latex-extra \
+    texlive-latex-recommended \
+    zip \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/* \
+    && pip3 install \
+    sphinx==1.5.6 \
+    sphinxcontrib-httpdomain \
+    sphinxcontrib-openapi \
+    sphinx_rtd_theme
+
+WORKDIR /project/sawtooth-seth/docs
+CMD make html latexpdf


### PR DESCRIPTION
Adds template files from `sawtooth-core` and update the `sawtooth-build-docs` Dockerfile and usage.

**FIXME**: links to `sawtooth-core` documentation do not work