### PR TITLE
Make links to Sawtooth docs point at external site

### DIFF
--- a/docs/source/introduction.rst
+++ b/docs/source/introduction.rst
@@ -133,7 +133,7 @@ dev_mode and PoET.
     which simulates the secure instructions. This should make it easier for
     the community to work with the software but also forgoes Byzantine fault
     tolerance.  For more information, see
-    `PoET 1.0 Specification <../architecture/poet>`.
+    `PoET 1.0 Specification <https://sawtooth.hyperledger.org/docs/core/releases/latest/architecture/poet.html>`.
 
 
 Getting Sawtooth

--- a/docs/source/seth_developers_guide/seth_transaction_family_spec.rst
+++ b/docs/source/seth_developers_guide/seth_transaction_family_spec.rst
@@ -455,10 +455,9 @@ Events
 Ethereum defines a set of LOGX for X in [0, 4] instructions that allow contracts
 to log off-chain data. Solidity uses these instructions to implement an event
 subscription system. To make Seth compatible with both, the LOGX instructions
-generate `Sawtooth Events
-</architecture/events_and_transactions_receipts>`. Like Seth's transaction
-receipts, these events contain only the data that is available during
-transaction execution.
+generate `Sawtooth Events <https://sawtooth.hyperledger.org/docs/core/releases/latest/architecture/events_and_transactions_receipts.html>`.
+Like Seth's transaction receipts, these events contain only the data that is
+available during transaction execution.
 
 The ``event_type`` field is set to ``“seth_log_event”``. The ``event_data``
 field contains a copy of the data argument passed to the EVM LOGX instruction.


### PR DESCRIPTION
Changed some relative links that used to point at pages in the core documentation to use the URL for the pages at the published site.

This is the fix suggested by @dcmiddle in #4 comments.