### PR TITLE
Use the 1-0 branch of sawtooth-core in the build_seth script

### DIFF
--- a/bin/build_seth
+++ b/bin/build_seth
@@ -40,6 +40,9 @@ if [ ! -e /tmp/sawtooth-core ];
 then
     git clone https://github.com/hyperledger/sawtooth-core
 fi
+cd sawtooth-core
+git fetch origin
+git checkout 1-0
 cd $top_dir
 # Go
 rsync -aH /tmp/sawtooth-core/sdk/go/src/sawtooth_sdk $seth_dir/src/


### PR DESCRIPTION
Changes the `build_seth` script so that it uses the main `1-0` branch of https://github.com/hyperledger/sawtooth-core when copying files.

This will fix issues noted by @aludvik with #5 when building.