### PR TITLE
Fix account nonce usage in RPC interface

### DIFF
--- a/families/seth/rpc/src/client.rs
+++ b/families/seth/rpc/src/client.rs
@@ -272,7 +272,7 @@ impl<S: MessageSender> ValidatorClient<S> {
         }
     }
 
-    fn make_batch(&self, from: &str, txn: SethTransaction) -> Result<(Batch, String), Error> {
+    pub fn make_batch(&self, from: &str, txn: SethTransaction) -> Result<(Batch, String), Error> {
         let payload = protobuf::Message::write_to_bytes(&txn.to_pb()).map_err(|error|
             Error::ParseError(String::from(
                 format!("Error serializing payload: {:?}", error))))?;

--- a/families/seth/src/burrow/evm/fake_app_state.go
+++ b/families/seth/src/burrow/evm/fake_app_state.go
@@ -89,6 +89,6 @@ func createAddress(creator *Account) Word256 {
 	creator.Nonce += 1
 	temp := make([]byte, 32+8)
 	copy(temp, creator.Address[:])
-	PutInt64BE(temp[32:], nonce)
+	PutUint64BE(temp[32:], nonce)
 	return LeftPadWord256(sha3.Sha3(temp)[:20])
 }

--- a/families/seth/src/burrow/evm/types.go
+++ b/families/seth/src/burrow/evm/types.go
@@ -29,7 +29,7 @@ type Account struct {
 	Address Word256
 	Balance int64
 	Code    []byte
-	Nonce   int64
+	Nonce   uint64
 	Other   interface{} // For holding all other data.
 
 	Permissions ptypes.AccountPermissions

--- a/families/seth/src/protos/seth.proto
+++ b/families/seth/src/protos/seth.proto
@@ -27,7 +27,7 @@ message EvmStateAccount {
     bytes address = 1;
     int64 balance = 2;
     bytes code = 3;
-    int64 nonce = 4;
+    uint64 nonce = 4;
     EvmPermissions permissions = 5;
 
     // In a future iteration, a storage_root field may be added so account data

--- a/families/seth/src/sawtooth_seth/processor/handler/sawtooth_app_state.go
+++ b/families/seth/src/sawtooth_seth/processor/handler/sawtooth_app_state.go
@@ -136,7 +136,7 @@ func (s *SawtoothAppState) CreateAccount(creator *Account) *Account {
 }
 
 // GetStorage gets the 256 bit value stored with the given key in the given
-// account. panics if the account and key do not both exist.
+// account, returns zero if the key does not exist.
 func (s *SawtoothAppState) GetStorage(address, key Word256) Word256 {
 	addrBytes := address.Bytes()[Word256Length-20:]
 	vmAddress, err := NewEvmAddrFromBytes(addrBytes)
@@ -157,9 +157,8 @@ func (s *SawtoothAppState) GetStorage(address, key Word256) Word256 {
 		}
 	}
 
-	panic(fmt.Sprint(
-		"Key %v not set for account %v", key.Bytes(), vmAddress,
-	))
+	logger.Debugf("Key %v not set for account %v", key.Bytes(), vmAddress)
+	return Zero256
 }
 
 func (s *SawtoothAppState) SetStorage(address, key, value Word256) {


### PR DESCRIPTION
Set the account nonce to the correct value when creating transactions, to allow clients like Truffle to work properly. Also changes the type to `uint64` to match other occurrences and makes `GetStorage` return 0 for initial accesses to  location, as per EVM spec for `SLOAD`. 