### PR TITLE
Only use 20 bytes of contract address in receipts

### DIFF
--- a/families/seth/rpc/src/transactions.rs
+++ b/families/seth/rpc/src/transactions.rs
@@ -223,7 +223,7 @@ impl SethReceipt {
             .map(SethLog::from_event_pb)
             .collect::<Result<Vec<SethLog>, Error>>()?;
 
-        let contract_address = transform::bytes_to_hex_str(seth_receipt_pb.get_contract_address());
+        let contract_address = transform::bytes_to_hex_str(&seth_receipt_pb.get_contract_address()[12..32]);
         let gas_used = seth_receipt_pb.get_gas_used();
         let return_value = transform::bytes_to_hex_str(seth_receipt_pb.get_return_value());
 


### PR DESCRIPTION
The contract addresses used in the Ethereum RPC interface should only be 20 bytes long, so remove the leading bytes which are `00` anyway.