### PR TITLE
Update various Ethereum RPC methods

### DIFF
--- a/families/seth/rpc/src/calls/network.rs
+++ b/families/seth/rpc/src/calls/network.rs
@@ -40,10 +40,15 @@ pub fn version<T>(_params: Params, mut _client: ValidatorClient<T>) -> Result<Va
     Ok(Value::String(String::from(SAWTOOTH_NET_VERSION)))
 }
 
-// Since this is only for HTTP right now, there won't be any connected peers
-pub fn peer_count<T>(_params: Params, mut _client: ValidatorClient<T>) -> Result<Value, Error> where T: MessageSender {
+// Return the number of actual Sawtooth peers
+pub fn peer_count<T>(_params: Params, mut client: ValidatorClient<T>) -> Result<Value, Error> where T: MessageSender {
     info!("net_peerCount");
-    Ok(Value::String(format!("{:#x}", 0)))
+    let n = match client.get_peers() {
+        Err(_) => 0,
+        Ok(n) => n,
+    };
+
+    Ok(Value::String(format!("{:#x}", n)))
 }
 
 // Return whether we are listening for connections, which is always true

--- a/families/seth/rpc/src/calls/transaction.rs
+++ b/families/seth/rpc/src/calls/transaction.rs
@@ -53,6 +53,7 @@ pub fn get_method_list<T>() -> Vec<(String, RequestHandler<T>)> where T: Message
     methods.push((String::from("eth_estimateGas"), estimate_gas));
     methods.push((String::from("eth_sign"), sign));
     methods.push((String::from("eth_call"), call));
+    methods.push((String::from("eth_syncing"), syncing));
 
     methods
 }
@@ -345,4 +346,10 @@ pub fn call<T>(_params: Params, mut _client: ValidatorClient<T>) -> Result<Value
     info!("eth_call");
     // Implementing this requires running the EVM, which is not possible within the RPC.
     Err(error::not_implemented())
+}
+
+// Always return false
+pub fn syncing<T>(_params: Params, mut _client: ValidatorClient<T>) -> Result<Value, Error> where T: MessageSender {
+    info!("eth_syncing");
+    Ok(Value::Bool(false))
 }

--- a/families/seth/rpc/src/client.rs
+++ b/families/seth/rpc/src/client.rs
@@ -58,6 +58,11 @@ use sawtooth_sdk::messages::client_batch_submit::{
 use sawtooth_sdk::messages::client_list_control::{
     ClientPagingControls,
 };
+use sawtooth_sdk::messages::client_peers::{
+    ClientPeersGetRequest,
+    ClientPeersGetResponse,
+    ClientPeersGetResponse_Status,
+};
 use sawtooth_sdk::messages::transaction::{Transaction as TransactionPb, TransactionHeader};
 use sawtooth_sdk::messages::batch::{Batch, BatchHeader};
 use sawtooth_sdk::messages::block::{BlockHeader};
@@ -670,4 +675,25 @@ impl<S: MessageSender> ValidatorClient<S> {
                 .map(|block_header: BlockHeader|
                     String::from(block_header.state_root_hash)))
     }
+
+
+    pub fn get_peers(&mut self) -> Result<usize, Error> {
+        let request = ClientPeersGetRequest::new();
+        let response: ClientPeersGetResponse =
+            self.send_request(Message_MessageType::CLIENT_PEERS_GET_REQUEST, &request)?;
+
+        let peers = match response.status {
+            ClientPeersGetResponse_Status::STATUS_UNSET => {
+                return Err(Error::ValidatorError);
+            },
+            ClientPeersGetResponse_Status::OK => response.peers,
+            ClientPeersGetResponse_Status::ERROR => {
+                return Err(Error::ValidatorError);
+            },
+        };
+
+        let n = peers.iter().count();
+        Ok(n)
+    }
+
 }


### PR DESCRIPTION
- Adds `QUANTITY|TAG` support for the `eth_getBlockTransactionCountByNumber`,
`eth_getBlockByNumber` and `eth_getTransactionByBlockNumberAndIndex` methods and implements the `full` boolean for return complete transaction details.
- Adds an `eth_syncing` method that always returns false.
- Add a `net_peerCount` method that return the total number of validator peers in the network.