### PR TITLE
Create initial MAINTAINERS list

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -1,0 +1,5 @@
+| Name | GitHub | RocketChat |
+| --- | --- | --- |
+| Adam Ludvik | aludvik | adamludvik |
+| Andrew Donald Kennedy | grkvlt | grkvlt |
+| Darian Plumb | dplumb94 | dplumb |


### PR DESCRIPTION
This list is intended to recognize current contributors to the
sawtooth-seth repository who have:

- Been actively involved for a substantial amount of time
- Made significant contributions that have been critical to the success
  of the project
- Frequently reviewed pull requests and left thoughtful and
  constructive feedback

To come up with this list objectively, I had to use some git-fu as the repo
also contains a lot of commits from sawtooth-core, so GitHub insights was not
sufficient.

I started by counting all commits in the repository that touched either
`families/burrow_evm` or `families/seth` in core before the commit where the
component was moved out of core, which was
f6fb1bd80e12f668d9d9e70e6150b3db7ad6f7f6

To accomplish this, I did:

    git log -- families/burrow_evm families/seth | grep Author | awk '{ print $2 }' | sort | uniq -c | sort -r

The cutoff commit was on `Thu Nov 16 15:14:54 2017 -0600`.

After this point, commits to the repo only contained commits to sawtooth-seth
(no sawtooth-core) so I was able to use GitHub insights from that date to the
present. That list can be found here:

https://github.com/hyperledger/sawtooth-seth/graphs/contributors?from=2017-11-17&to=2018-03-29&type=c

I merged the commit counts from these two lists and took all the names that had
more than 10 commits.

The list has been sorted by first name.

Signed-off-by: Adam Ludvik <ludvik@bitwise.io>