### PR TITLE
Update jsonrpc library

### DIFF
--- a/rpc/Cargo.toml
+++ b/rpc/Cargo.toml
@@ -19,8 +19,8 @@ version = "0.1.0"
 authors = ["sawtooth"]
 
 [dependencies]
-jsonrpc-core = "7.1"
-jsonrpc-http-server = "7.1"
+jsonrpc-core = "8.0"
+jsonrpc-http-server = "8.0"
 futures-cpupool = "0.1"
 clap = "2.26"
 protobuf="1.4"

--- a/rpc/src/main.rs
+++ b/rpc/src/main.rs
@@ -102,7 +102,7 @@ fn main() {
     let methods = get_method_list();
     for (name, method) in methods {
         let clone = executor.clone();
-        io.add_async_method(&name, move |params: Params| {
+        io.add_method(&name, move |params: Params| {
             clone.run(params, method)
         });
     }

--- a/rpc/src/requests.rs
+++ b/rpc/src/requests.rs
@@ -39,7 +39,7 @@ impl<T: MessageSender + Clone + Sync + Send + 'static> RequestExecutor<T> {
         }
     }
 
-    pub fn run(&self, params: Params, handler: RequestHandler<T>) -> BoxFuture<Value, Error> {
+    pub fn run(&self, params: Params, handler: RequestHandler<T>) -> BoxFuture<Value> {
         let client = self.client.clone();
         Box::new(self.pool.spawn_fn(move || {handler(params, client)}))
     }

--- a/rpc/tests/Dockerfile
+++ b/rpc/tests/Dockerfile
@@ -15,8 +15,6 @@
 
 FROM ubuntu:xenial
 
-COPY . /project/sawtooth-seth
-
 RUN echo "deb apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 8AA7AF1F1091A5FD" \
  && echo 'deb http://repo.sawtooth.me/ubuntu/1.0/stable xenial universe' >> /etc/apt/sources.list \
  && apt-get update \
@@ -29,6 +27,8 @@ RUN echo "deb apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 
     python3-zmq \
  && apt-get clean \
  && rm -rf /var/lib/apt/lists/*
+
+COPY . /project/sawtooth-seth
 
 ENV PATH=$PATH:/project/sawtooth-seth/bin
 


### PR DESCRIPTION
The jsonrpc library was changed and causing some errors when trying to call RPC methods. This commit updates the library and the related API calls, which has fixed the issue.