### PR TITLE
Remove CLI call and share key dir

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -26,6 +26,7 @@ services:
     container_name: seth-cli
     volumes:
       - ./contracts:/project/sawtooth-seth/contracts
+      - sawtooth:/root/.sawtooth
     depends_on:
       - rest-api
     working_dir: /project/sawtooth-seth
@@ -113,6 +114,8 @@ services:
         ISOLATION_ID: ${ISOLATION_ID}
     image: sawtooth-seth-rpc:${ISOLATION_ID}
     container_name: seth-rpc
+    volumes:
+      - sawtooth:/root/.sawtooth
     depends_on:
       - validator
     ports:
@@ -121,3 +124,6 @@ services:
       bash -c "
         seth-rpc --connect tcp://validator:4004 --bind 0.0.0.0:3030
       "
+
+volumes:
+  sawtooth:

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -119,6 +119,5 @@ services:
       - 3030:3030
     command: |
       bash -c "
-        seth init http://rest-api:8080 &&
         seth-rpc --connect tcp://validator:4004 --bind 0.0.0.0:3030
       "

--- a/rpc/comp_seth_rpc.yaml
+++ b/rpc/comp_seth_rpc.yaml
@@ -30,8 +30,8 @@ services:
     environment:
       RUST_BACKTRACE: 1
     command: "bash -c \"
-      mkdir -p ~/.sawtooth/ &&
-      cp tests/data/test.pem ~/.sawtooth/test.pem &&
+      mkdir -p ~/.sawtooth/keys/ &&
+      cp tests/data/test.pem ~/.sawtooth/keys/test.pem &&
       cargo run --
         --connect tcp://comp-seth-rpc:4004
         --bind 0.0.0.0:3030

--- a/rpc/src/accounts.rs
+++ b/rpc/src/accounts.rs
@@ -84,7 +84,7 @@ impl From<SigningError> for Error {
 }
 
 fn get_data_dir() -> PathBuf {
-    [&env!("HOME"), ".sawtooth"].iter().collect()
+    [&env!("HOME"), ".sawtooth", "keys"].iter().collect()
 }
 
 impl Account {


### PR DESCRIPTION
- A Seth CLI call was not removed from a Docker Compose command when Seth CLI functionality was removed from the RPC container, which caused a bug when running the Docker Compose file. This PR removes that command

- The  Seth CLI uses `~/.sawtooth/keys` as the default key dir, while the Seth JSON RPC previously used `~/.sawtooth`. This PR updates the RPC to use the keys dir so that the keys can be shared between the components

- Adds a mounted volume to share keys between the seth client and RPC. This way we do not need Seth CLI functionality in the RPC container