### PR TITLE
Add proxy to build.args in docker-compose-installed file

### DIFF
--- a/docker-compose-installed.yaml
+++ b/docker-compose-installed.yaml
@@ -21,7 +21,11 @@ services:
       context: .
       dockerfile: ./cli/Dockerfile-installed
       args:
-        ISOLATION_ID: ${ISOLATION_ID}
+        args:
+        - ISOLATION_ID=${ISOLATION_ID}
+        - http_proxy
+        - https_proxy
+        - no_proxy
     image: sawtooth-seth-cli:${ISOLATION_ID}
     container_name: seth-cli
     volumes:
@@ -45,7 +49,11 @@ services:
       context: .
       dockerfile: ./processor/Dockerfile-installed
       args:
-        ISOLATION_ID: ${ISOLATION_ID}
+        args:
+        - ISOLATION_ID=${ISOLATION_ID}
+        - http_proxy
+        - https_proxy
+        - no_proxy
     image: sawtooth-seth-tp:${ISOLATION_ID}
     container_name: seth-tp
     volumes:
@@ -115,15 +123,20 @@ services:
       context: .
       dockerfile: ./rpc/Dockerfile-installed
       args:
-        ISOLATION_ID: ${ISOLATION_ID}
+        - ISOLATION_ID=${ISOLATION_ID}
+        - http_proxy
+        - https_proxy
+        - no_proxy
     image: sawtooth-seth-rpc:${ISOLATION_ID}
     container_name: seth-rpc
     volumes:
       - ./build/debs:/build
     depends_on:
       - validator
+    expose:
+      - 3030    
     ports:
-      - 3030:3030
+      - '3030:3030'
     command: |
       bash -c "
         cp /debs/*.deb /build


### PR DESCRIPTION
For Seth-RPC to properly work, add proxy to build.args is required in both docker-composed-installed, and as already accepted in PR for docker-composed file [https://github.com/hyperledger/sawtooth-seth/commit/5abdec015738ee2c7ca4386aeb844e2cf4de560c]. After adding proxy to build.args in docker-compose-installed. Related PR is #36

Also
expose:
- 3030
and 
ports:
      - '3030:3030'

This is my commit message

Signed-off-by: cliveb `<clive.boulton@gmail.com>`