### PR TITLE
Removed `seth init` line from RPC service command

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -124,10 +124,12 @@ services:
     container_name: seth-rpc
     depends_on:
       - validator
+    expose:
+      - 3030 
     ports:
-      - 3030:3030
+      - '3030:3030'
     command: |
       bash -c "
-        seth init http://rest-api:8080 &&
         seth-rpc --connect tcp://validator:4004 --bind 0.0.0.0:3030
       "
+


### PR DESCRIPTION
After adding proxy to build.args in docker-compose-installed. Related PR is https://github.com/hyperledger/sawtooth-seth/pull/35. The RPC does not start up properly in the docker-compose file. BWO of asking and testing the `seth init` line can be removed from the RPC service command. So the RPC does not try to startup improperly.  To check the RPC endpoint is working, on a new Terminal run the following curl to test.  [documentation](https://sawtooth.hyperledger.org/docs/seth/releases/latest/seth_developers_guide/getting_started.html#creating-an-account)

This is my commit message

Signed-off-by: cliveb `<clive.boulton@gmail.com>`