### PR TITLE
Show EventType in CLI responses

### DIFF
--- a/cli/src/seth_cli/client/response.go
+++ b/cli/src/seth_cli/client/response.go
@@ -102,7 +102,7 @@ type TransactionReceipt struct {
 	Data   []string
 }
 type Event struct {
-	EventType  string
+	EventType  string `json:"event_type"`
 	Attributes []struct {
 		Key   string
 		Value string


### PR DESCRIPTION
Fixes STL-699. Go was ignoring the `event_type` JSON field due to the snake cased-name. This PR adds a struct tag that makes Go associate the `EventType` struct field with the `event_type` JSON field.

Signed-off-by: Kenneth Koski <knkski@bitwise.io>