### PR TITLE
Handle nonce-less account creation

### DIFF
--- a/cli/src/seth_cli/client/client.go
+++ b/cli/src/seth_cli/client/client.go
@@ -118,6 +118,12 @@ func (c *Client) LookupAccountNonce(priv []byte) (uint64, error) {
 			addr, err,
 		)
 	}
+
+	// `Client.Get` can return `nil, nil` when e.g. it gets a 404 response
+	if entry == nil {
+		return 0, nil
+	}
+
 	return uint64(entry.Account.Nonce), nil
 }
 


### PR DESCRIPTION
When attempting to grab the nonce associated with an account during account creation, `Client.Get` will return `nil, nil` due to the account not yet existing. This PR updates `Client.LookupAccountNonce` to handle that scenario and default to `0` for the nonce instead.

Signed-off-by: Kenneth Koski <knkski@bitwise.io>