### PR TITLE
Share key dir between cli and rpc containers

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -29,6 +29,7 @@ services:
     container_name: seth-cli
     volumes:
       - ./contracts:/project/sawtooth-seth/contracts
+      - sawtooth:/root/.sawtooth
     depends_on:
       - rest-api
     working_dir: /project/sawtooth-seth
@@ -122,6 +123,8 @@ services:
         - no_proxy
     image: sawtooth-seth-rpc:${ISOLATION_ID}
     container_name: seth-rpc
+    volumes:
+      - sawtooth:/root/.sawtooth
     depends_on:
       - validator
     ports:
@@ -130,3 +133,6 @@ services:
       bash -c "
         seth-rpc --connect tcp://validator:4004 --bind 0.0.0.0:3030
       "
+
+volumes:
+  sawtooth:

--- a/rpc/comp_seth_rpc.yaml
+++ b/rpc/comp_seth_rpc.yaml
@@ -30,8 +30,8 @@ services:
     environment:
       RUST_BACKTRACE: 1
     command: "bash -c \"
-      mkdir -p ~/.sawtooth/ &&
-      cp tests/data/test.pem ~/.sawtooth/test.pem &&
+      mkdir -p ~/.sawtooth/keys/ &&
+      cp tests/data/test.pem ~/.sawtooth/keys/test.pem &&
       cargo run --
         --connect tcp://comp-seth-rpc:4004
         --bind 0.0.0.0:3030

--- a/rpc/src/accounts.rs
+++ b/rpc/src/accounts.rs
@@ -83,15 +83,15 @@ impl From<SigningError> for Error {
     }
 }
 
-fn get_data_dir() -> PathBuf {
-    [&env!("HOME"), ".sawtooth"].iter().collect()
+fn get_key_dir() -> PathBuf {
+    [&env!("HOME"), ".sawtooth", "keys"].iter().collect()
 }
 
 impl Account {
     pub fn load_from_alias(alias: &str) -> Result<Account, Error> {
-        let mut key_path = get_data_dir();
-        key_path.push(alias);
-        let pem = key_path.with_extension("pem");
+        let mut key_dir = get_key_dir();
+        key_dir.push(alias);
+        let pem = key_dir.with_extension("pem");
 
         let key = {
             if pem.as_path().is_file() {


### PR DESCRIPTION
The Seth RPC container relies on keys that were generated by the CLI. Previously, we were generating those keys inside of the RPC container with a CLI call. This PR moves to sharing a key directory between the CLI and RPC containers, with the CLI container generating the keys in that directory.

Remix of #28. This PR punts on the issue of using `SAWTOOTH_HOME` / `SAWTOOTH_KEYS` environment variables as per https://github.com/hyperledger/sawtooth-seth/pull/28#issuecomment-388647413. It also switches from a `get_data_dir` to a `get_key_dir`, as `get_data_dir` is then otherwise unused apart from `get_key_dir`.

Signed-off-by: Kenneth Koski <knkski@bitwise.io>