### PR TITLE
Skip invalid addresses in contract listing

### DIFF
--- a/cli/src/seth_cli/cli/contract_list.go
+++ b/cli/src/seth_cli/cli/contract_list.go
@@ -70,7 +70,21 @@ func (args *ContractList) Run(config *Config) error {
 	)
 	var i uint64
 	for i = 1; i < nonce; i++ {
-		fmt.Printf("%v: %v\n", i, addr.Derive(i))
+		var derived = addr.Derive(i)
+		entry, err := client.Get(derived.Bytes())
+
+		// Abort on error
+		if err != nil {
+			fmt.Printf("Encountered error while listing contracts: %s", err)
+			break
+		}
+
+		// Skip non-existent contracts
+		if entry == nil {
+			continue
+		}
+
+		fmt.Printf("%v: %v\n", i, derived)
 	}
 
 	return nil


### PR DESCRIPTION
Fixes [STL-1169](https://jira.hyperledger.org/browse/STL-1169).

When a contract is successfully called, the caller account's nonce is incremented, which causes spurious addresses to show up for "seth list {alias}". This PR adds a change to the contract list code that checks that each address it displays is actually valid.

Signed-off-by: Kenneth Koski <knkski@bitwise.io>