### PR TITLE
Add Cargo format check

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -68,6 +68,7 @@ node ('master') {
 
         stage("Run Lint") {
             sh 'docker run --rm sawtooth-seth-cli:$ISOLATION_ID run_go_fmt'
+            sh 'cd rpc/ && cargo fmt -- --check'
         }
 
         // Run the tests

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -69,6 +69,7 @@ node ('master') {
         stage("Run Lint") {
             sh 'docker run --rm sawtooth-seth-cli:$ISOLATION_ID run_go_fmt'
             sh 'cd rpc/ && cargo fmt -- --check'
+            sh 'cd rpc/ && cargo clippy -- -Dwarnings'
         }
 
         // Run the tests


### PR DESCRIPTION
This will enforce that PRs have run `cargo fmt` before they are merged, and prevent formatting drift.

Signed-off-by: Kenneth Koski <knkski@bitwise.io>