### PR TITLE
Clippy lint fixes

### DIFF
--- a/rpc/src/calls/account.rs
+++ b/rpc/src/calls/account.rs
@@ -48,11 +48,9 @@ fn validate_block_key(block: &str) -> Result<BlockKey, Error> {
     match block.parse() {
         Ok(k) => Ok(k),
         Err(BlockKeyParseError::Invalid) => {
-            return Err(Error::invalid_params("Failed to parse block number"));
+            Err(Error::invalid_params("Failed to parse block number"))
         }
-        Err(BlockKeyParseError::Unsupported) => {
-            return Err(error::not_implemented());
-        }
+        Err(BlockKeyParseError::Unsupported) => Err(error::not_implemented()),
     }
 }
 

--- a/rpc/src/calls/account.rs
+++ b/rpc/src/calls/account.rs
@@ -44,7 +44,7 @@ where
     methods
 }
 
-fn validate_block_key(block: String) -> Result<BlockKey, Error> {
+fn validate_block_key(block: &str) -> Result<BlockKey, Error> {
     match block.parse() {
         Ok(k) => Ok(k),
         Err(BlockKeyParseError::Invalid) => {
@@ -56,7 +56,7 @@ fn validate_block_key(block: String) -> Result<BlockKey, Error> {
     }
 }
 
-fn validate_account_address(address: String) -> Result<String, Error> {
+fn validate_account_address(address: &str) -> Result<String, Error> {
     if address.len() != 42 {
         Err(Error::invalid_params(format!(
             "Invalid address length: {} != {}",
@@ -68,7 +68,7 @@ fn validate_account_address(address: String) -> Result<String, Error> {
     }
 }
 
-fn validate_storage_address(address: String) -> Result<String, Error> {
+fn validate_storage_address(address: &str) -> Result<String, Error> {
     if address.len() < 4 || address.len() % 2 != 0 {
         Err(Error::invalid_params(format!(
             "Invalid storage position: {}",
@@ -79,6 +79,7 @@ fn validate_storage_address(address: String) -> Result<String, Error> {
     }
 }
 
+#[allow(needless_pass_by_value)]
 pub fn get_balance<T>(params: Params, client: ValidatorClient<T>) -> Result<Value, Error>
 where
     T: MessageSender,
@@ -89,6 +90,7 @@ where
     })
 }
 
+#[allow(needless_pass_by_value)]
 pub fn get_storage_at<T>(params: Params, mut client: ValidatorClient<T>) -> Result<Value, Error>
 where
     T: MessageSender,
@@ -103,11 +105,11 @@ where
         }
     };
 
-    let key = validate_block_key(block)?;
-    let account_address = validate_account_address(address)?;
-    let storage_address = validate_storage_address(position)?;
+    let key = validate_block_key(&block)?;
+    let account_address = validate_account_address(&address)?;
+    let storage_address = validate_storage_address(&position)?;
 
-    match client.get_storage_at(account_address, storage_address, key) {
+    match client.get_storage_at(&account_address, &storage_address, key) {
         Ok(Some(value)) => Ok(transform::hex_prefix(&transform::bytes_to_hex_str(&value))),
         Ok(None) => Ok(Value::Null),
         Err(error) => {
@@ -117,6 +119,7 @@ where
     }
 }
 
+#[allow(needless_pass_by_value)]
 pub fn get_code<T>(params: Params, client: ValidatorClient<T>) -> Result<Value, Error>
 where
     T: MessageSender,
@@ -127,6 +130,7 @@ where
     })
 }
 
+#[allow(needless_pass_by_value)]
 pub fn get_transaction_count<T>(params: Params, client: ValidatorClient<T>) -> Result<Value, Error>
 where
     T: MessageSender,
@@ -137,6 +141,7 @@ where
     })
 }
 
+#[allow(needless_pass_by_value)]
 fn get_account<T, F>(params: Params, mut client: ValidatorClient<T>, f: F) -> Result<Value, Error>
 where
     T: MessageSender,
@@ -152,10 +157,10 @@ where
         }
     };
 
-    let key = validate_block_key(block)?;
-    let address = validate_account_address(address)?;
+    let key = validate_block_key(&block)?;
+    let address = validate_account_address(&address)?;
 
-    match client.get_account(address, key) {
+    match client.get_account(&address, key) {
         Ok(Some(account)) => Ok(f(account)),
         Ok(None) => Ok(Value::Null),
         Err(error) => {
@@ -165,6 +170,7 @@ where
     }
 }
 
+#[allow(needless_pass_by_value)]
 pub fn accounts<T>(_params: Params, client: ValidatorClient<T>) -> Result<Value, Error>
 where
     T: MessageSender,

--- a/rpc/src/calls/block.rs
+++ b/rpc/src/calls/block.rs
@@ -70,9 +70,7 @@ where
         }
     };
 
-    Ok(Value::String(
-        format!("{:#x}", block_header.block_num).into(),
-    ))
+    Ok(Value::String(format!("{:#x}", block_header.block_num)))
 }
 
 fn get_block_obj<T>(

--- a/rpc/src/calls/block.rs
+++ b/rpc/src/calls/block.rs
@@ -131,7 +131,7 @@ where
     };
     let mut transactions = Vec::new();
     let mut gas: u64 = 0;
-    for (txn_id, receipt) in receipts.into_iter() {
+    for (txn_id, receipt) in receipts {
         if full {
             let (txn, _) =
                 match client.get_transaction_and_block(&TransactionKey::Signature(txn_id)) {

--- a/rpc/src/calls/block.rs
+++ b/rpc/src/calls/block.rs
@@ -53,6 +53,7 @@ where
 }
 
 // Return the block number of the current chain head, in hex, as a string
+#[allow(needless_pass_by_value)]
 pub fn block_number<T>(_params: Params, mut client: ValidatorClient<T>) -> Result<Value, Error>
 where
     T: MessageSender,
@@ -139,7 +140,7 @@ where
                         return Err(Error::internal_error());
                     }
                 };
-            transactions.push(transform::make_txn_obj_no_block(txn))
+            transactions.push(transform::make_txn_obj_no_block(&txn))
         } else {
             transactions.push(transform::hex_prefix(&txn_id));
         }

--- a/rpc/src/calls/error.rs
+++ b/rpc/src/calls/error.rs
@@ -18,9 +18,9 @@
 use jsonrpc_core::{Error, ErrorCode};
 
 pub fn not_implemented() -> Error {
-    return Error {
+    Error {
         code: ErrorCode::ServerError(-1),
         message: String::from("Method not implemented"),
         data: None,
-    };
+    }
 }

--- a/rpc/src/calls/logs.rs
+++ b/rpc/src/calls/logs.rs
@@ -53,6 +53,7 @@ where
     methods
 }
 
+#[allow(needless_pass_by_value)]
 pub fn new_filter<T>(params: Params, mut client: ValidatorClient<T>) -> Result<Value, Error>
 where
     T: MessageSender,
@@ -61,7 +62,7 @@ where
     let (filter,): (Map<String, Value>,) = params
         .parse()
         .map_err(|_| Error::invalid_params("Takes [filter: OBJECT]"))?;
-    let log_filter = LogFilter::from_map(filter)?;
+    let log_filter = LogFilter::from_map(&filter)?;
 
     let current_block = client.get_current_block_number().map_err(|error| {
         error!("Failed to get current block number: {}", error);
@@ -75,6 +76,7 @@ where
     Ok(transform::hex_prefix(&filter_id_to_hex(filter_id)))
 }
 
+#[allow(needless_pass_by_value)]
 pub fn new_block_filter<T>(_params: Params, mut client: ValidatorClient<T>) -> Result<Value, Error>
 where
     T: MessageSender,
@@ -88,6 +90,7 @@ where
     Ok(transform::hex_prefix(&filter_id_to_hex(filter_id)))
 }
 
+#[allow(needless_pass_by_value)]
 pub fn new_pending_transaction_filter<T>(
     _params: Params,
     mut client: ValidatorClient<T>,
@@ -106,6 +109,7 @@ where
     Ok(transform::hex_prefix(&filter_id_to_hex(filter_id)))
 }
 
+#[allow(needless_pass_by_value)]
 pub fn uninstall_filter<T>(params: Params, mut client: ValidatorClient<T>) -> Result<Value, Error>
 where
     T: MessageSender,
@@ -123,6 +127,7 @@ where
     ))
 }
 
+#[allow(needless_pass_by_value)]
 pub fn get_filter_changes<T>(params: Params, mut client: ValidatorClient<T>) -> Result<Value, Error>
 where
     T: MessageSender,
@@ -192,6 +197,7 @@ where
     Ok(Value::Array(response))
 }
 
+#[allow(needless_pass_by_value)]
 pub fn get_filter_logs<T>(params: Params, mut client: ValidatorClient<T>) -> Result<Value, Error>
 where
     T: MessageSender,
@@ -222,6 +228,7 @@ where
     }
 }
 
+#[allow(needless_pass_by_value)]
 pub fn get_logs<T>(params: Params, mut client: ValidatorClient<T>) -> Result<Value, Error>
 where
     T: MessageSender,
@@ -230,7 +237,7 @@ where
     let (filter,): (Map<String, Value>,) = params
         .parse()
         .map_err(|_| Error::invalid_params("Takes [filter: OBJECT]"))?;
-    let log_filter = LogFilter::from_map(filter)?;
+    let log_filter = LogFilter::from_map(&filter)?;
 
     get_logs_from_filter(&mut client, &log_filter)
 }

--- a/rpc/src/calls/logs.rs
+++ b/rpc/src/calls/logs.rs
@@ -210,10 +210,7 @@ where
             filter_id_from_hex(&s).map_err(|error| Error::invalid_params(format!("{}", error)))
         })?;
 
-    let FilterEntry {
-        filter,
-        last_block_sent: _,
-    } = client
+    let FilterEntry { filter, .. } = client
         .filters
         .get_filter(filter_id)
         .ok_or_else(|| Error::invalid_params(format!("Unknown filter id: {}", filter_id)))?;

--- a/rpc/src/calls/logs.rs
+++ b/rpc/src/calls/logs.rs
@@ -179,7 +179,7 @@ where
             .collect(),
         Filter::Log(log_filter) => {
             let mut all_logs = Vec::new();
-            for &(_, ref block) in blocks.iter() {
+            for &(_, ref block) in &blocks {
                 let logs = get_logs_from_block_and_filter(&mut client, block, &log_filter)?;
                 all_logs.extend(logs.into_iter());
             }
@@ -366,7 +366,7 @@ where
                 );
                 Error::internal_error()
             })?;
-        for log in logs.iter() {
+        for log in &logs {
             let log_obj = transform::make_log_obj(log, &txn_id, index as u64, block_id, block_num);
             log_objects.push(log_obj);
         }

--- a/rpc/src/calls/logs.rs
+++ b/rpc/src/calls/logs.rs
@@ -355,7 +355,7 @@ where
         .collect::<Vec<_>>();
 
     let mut log_objects = Vec::with_capacity(logs.len());
-    for (txn_id, logs) in logs.into_iter() {
+    for (txn_id, logs) in logs {
         let index = transactions
             .iter()
             .position(|txn| txn.header_signature == txn_id)

--- a/rpc/src/calls/logs.rs
+++ b/rpc/src/calls/logs.rs
@@ -123,7 +123,7 @@ where
         })?;
 
     Ok(Value::Bool(
-        client.filters.remove_filter(&filter_id).is_some(),
+        client.filters.remove_filter(filter_id).is_some(),
     ))
 }
 
@@ -145,7 +145,7 @@ where
         last_block_sent,
     } = client
         .filters
-        .get_filter(&filter_id)
+        .get_filter(filter_id)
         .ok_or_else(|| Error::invalid_params(format!("Unknown filter id: {}", filter_id)))?;
 
     let blocks = client.get_blocks_since(last_block_sent).map_err(|error| {
@@ -191,7 +191,7 @@ where
     // NOTE: Updating is delayed until there are no more error sources that could cause an early
     // return after upadting the filter
     if let Some(&(block_num, _)) = blocks.last() {
-        client.filters.update_latest_block(&filter_id, block_num);
+        client.filters.update_latest_block(filter_id, block_num);
     }
 
     Ok(Value::Array(response))
@@ -215,7 +215,7 @@ where
         last_block_sent: _,
     } = client
         .filters
-        .get_filter(&filter_id)
+        .get_filter(filter_id)
         .ok_or_else(|| Error::invalid_params(format!("Unknown filter id: {}", filter_id)))?;
 
     if let Filter::Log(log_filter) = filter {

--- a/rpc/src/calls/logs.rs
+++ b/rpc/src/calls/logs.rs
@@ -164,11 +164,7 @@ where
                             let header: Result<TransactionHeader, _> =
                                 protobuf::parse_from_bytes(&txn.header);
                             if let Ok(header) = header {
-                                if header.family_name == "seth" {
-                                    true
-                                } else {
-                                    false
-                                }
+                                header.family_name == "seth"
                             } else {
                                 false
                             }

--- a/rpc/src/calls/logs.rs
+++ b/rpc/src/calls/logs.rs
@@ -341,7 +341,7 @@ where
                 .collect();
             (txn_id, logs)
         })
-        .filter(|&(_, ref logs)| logs.len() > 0)
+        .filter(|&(_, ref logs)| !logs.is_empty())
         .collect();
     warn!("Filtered Logs: {:?}", logs);
 

--- a/rpc/src/calls/mod.rs
+++ b/rpc/src/calls/mod.rs
@@ -14,6 +14,7 @@
  * limitations under the License.
  * ------------------------------------------------------------------------------
  */
+#![allow(unknown_lints)]
 
 pub mod account;
 pub mod block;

--- a/rpc/src/calls/network.rs
+++ b/rpc/src/calls/network.rs
@@ -38,6 +38,7 @@ where
 }
 
 // Version refers to the particular network this JSON-RPC client is connected to
+#[allow(needless_pass_by_value)]
 pub fn version<T>(_params: Params, mut _client: ValidatorClient<T>) -> Result<Value, Error>
 where
     T: MessageSender,
@@ -47,6 +48,7 @@ where
 }
 
 // Return the number of actual Sawtooth peers
+#[allow(needless_pass_by_value)]
 pub fn peer_count<T>(_params: Params, mut client: ValidatorClient<T>) -> Result<Value, Error>
 where
     T: MessageSender,
@@ -61,6 +63,7 @@ where
 }
 
 // Return whether we are listening for connections, which is always true
+#[allow(needless_pass_by_value)]
 pub fn listening<T>(_params: Params, mut _client: ValidatorClient<T>) -> Result<Value, Error>
 where
     T: MessageSender,

--- a/rpc/src/calls/transaction.rs
+++ b/rpc/src/calls/transaction.rs
@@ -279,14 +279,14 @@ where
                 }
             };
             // We know the transaction index already, because get_transaction_and_block succeeded
-            match txn_key {
-                &TransactionKey::Index((index, _)) => Ok(transform::make_txn_obj(
+            match *txn_key {
+                TransactionKey::Index((index, _)) => Ok(transform::make_txn_obj(
                     txn,
                     index,
                     &block.header_signature,
                     block_header.block_num,
                 )),
-                &TransactionKey::Signature(ref txn_id) => {
+                TransactionKey::Signature(ref txn_id) => {
                     let txn_id = (*txn_id).clone();
                     let mut index = 0;
                     for mut batch in block.take_batches().into_iter() {

--- a/rpc/src/calls/transaction.rs
+++ b/rpc/src/calls/transaction.rs
@@ -96,9 +96,9 @@ where
 
     // Optional Arguments
     let to = transform::get_bytes_from_map(&txn, "to")?;
-    let gas = transform::get_u64_from_map(&txn, "gas").map(|g| g.unwrap_or(90000))?;
+    let gas = transform::get_u64_from_map(&txn, "gas").map(|g| g.unwrap_or(90_000))?;
     let gas_price =
-        transform::get_u64_from_map(&txn, "gasPrice").map(|g| g.unwrap_or(10000000000000))?;
+        transform::get_u64_from_map(&txn, "gasPrice").map(|g| g.unwrap_or(10_000_000_000_000))?;
     let value = transform::get_u64_from_map(&txn, "value").map(|g| g.unwrap_or(0))?;
     let nonce = transform::get_u64_from_map(&txn, "nonce").map(|g| g.unwrap_or(txn_count))?;
 

--- a/rpc/src/calls/transaction.rs
+++ b/rpc/src/calls/transaction.rs
@@ -309,7 +309,7 @@ where
                     }
                     // This should never happen, because we fetched the block and transaction
                     // together.
-                    return Err(Error::internal_error());
+                    Err(Error::internal_error())
                 }
             }
         }

--- a/rpc/src/calls/transaction.rs
+++ b/rpc/src/calls/transaction.rs
@@ -334,7 +334,7 @@ where
         .map_err(|_| Error::invalid_params("Takes [txnHash: DATA(64)]"))
         .and_then(|(v,): (String,)| {
             v.get(2..)
-                .map(|v| String::from(v))
+                .map(String::from)
                 .ok_or_else(|| Error::invalid_params("Invalid transaction hash, must have 0x"))
         })?;
     let receipt = match client.get_receipts(&[txn_id.clone()]) {
@@ -423,7 +423,7 @@ where
         .map_err(|_| Error::invalid_params("Takes [txnHash: DATA(64)]"))?;
     let address = address
         .get(2..)
-        .map(|a| String::from(a))
+        .map(String::from)
         .ok_or_else(|| Error::invalid_params("Address must have 0x prefix"))?;
 
     let payload = payload

--- a/rpc/src/calls/transaction.rs
+++ b/rpc/src/calls/transaction.rs
@@ -68,6 +68,7 @@ where
     methods
 }
 
+#[allow(needless_pass_by_value)]
 pub fn send_transaction<T>(params: Params, mut client: ValidatorClient<T>) -> Result<Value, Error>
 where
     T: MessageSender,
@@ -82,7 +83,7 @@ where
         .and_then(|f| f.ok_or_else(|| Error::invalid_params("`from` not set")))?;
     let data = transform::get_bytes_from_map(&txn, "data")
         .and_then(|f| f.ok_or_else(|| Error::invalid_params("`data` not set")))?;
-    let txn_count = match client.get_account(from.clone(), BlockKey::Latest) {
+    let txn_count = match client.get_account(&from, BlockKey::Latest) {
         Ok(Some(a)) => a.nonce,
         Ok(None) => {
             return Err(Error::invalid_params("Invalid `from` address"));
@@ -122,7 +123,7 @@ where
         SethTransaction::CreateContractAccount(txn)
     };
 
-    let txn_signature = client.send_transaction(&from, txn).map_err(|error| {
+    let txn_signature = client.send_transaction(&from, &txn).map_err(|error| {
         error!("{:?}", error);
         Error::internal_error()
     })?;
@@ -130,6 +131,7 @@ where
     Ok(transform::hex_prefix(&txn_signature))
 }
 
+#[allow(needless_pass_by_value)]
 pub fn send_raw_transaction<T>(
     _params: Params,
     mut _client: ValidatorClient<T>,
@@ -142,6 +144,7 @@ where
     Err(error::not_implemented())
 }
 
+#[allow(needless_pass_by_value)]
 pub fn get_transaction_by_hash<T>(
     params: Params,
     client: ValidatorClient<T>,
@@ -168,6 +171,7 @@ where
     get_transaction(client, &TransactionKey::Signature(txn_hash))
 }
 
+#[allow(needless_pass_by_value)]
 pub fn get_transaction_by_block_hash_and_index<T>(
     params: Params,
     client: ValidatorClient<T>,
@@ -210,6 +214,7 @@ where
     )
 }
 
+#[allow(needless_pass_by_value)]
 pub fn get_transaction_by_block_number_and_index<T>(
     params: Params,
     client: ValidatorClient<T>,
@@ -281,7 +286,7 @@ where
             // We know the transaction index already, because get_transaction_and_block succeeded
             match *txn_key {
                 TransactionKey::Index((index, _)) => Ok(transform::make_txn_obj(
-                    txn,
+                    &txn,
                     index,
                     &block.header_signature,
                     block_header.block_num,
@@ -293,7 +298,7 @@ where
                         for transaction in batch.take_transactions().into_iter() {
                             if transaction.header_signature == txn_id {
                                 return Ok(transform::make_txn_obj(
-                                    txn,
+                                    &txn,
                                     index,
                                     &block.header_signature,
                                     block_header.block_num,
@@ -310,11 +315,12 @@ where
         }
         None => {
             // Transaction exists, but isn't in a block yet
-            Ok(transform::make_txn_obj_no_block(txn))
+            Ok(transform::make_txn_obj_no_block(&txn))
         }
     }
 }
 
+#[allow(needless_pass_by_value)]
 pub fn get_transaction_receipt<T>(
     params: Params,
     mut client: ValidatorClient<T>,
@@ -387,6 +393,7 @@ where
     ))
 }
 
+#[allow(needless_pass_by_value)]
 pub fn gas_price<T>(_params: Params, mut _client: ValidatorClient<T>) -> Result<Value, Error>
 where
     T: MessageSender,
@@ -395,6 +402,7 @@ where
     Ok(Value::String(format!("{:#x}", 0)))
 }
 
+#[allow(needless_pass_by_value)]
 pub fn estimate_gas<T>(_params: Params, mut _client: ValidatorClient<T>) -> Result<Value, Error>
 where
     T: MessageSender,
@@ -404,6 +412,7 @@ where
     Err(error::not_implemented())
 }
 
+#[allow(needless_pass_by_value)]
 pub fn sign<T>(params: Params, client: ValidatorClient<T>) -> Result<Value, Error>
 where
     T: MessageSender,
@@ -453,6 +462,7 @@ where
     Ok(transform::hex_prefix(&signature))
 }
 
+#[allow(needless_pass_by_value)]
 pub fn call<T>(_params: Params, mut _client: ValidatorClient<T>) -> Result<Value, Error>
 where
     T: MessageSender,
@@ -463,6 +473,7 @@ where
 }
 
 // Always return false
+#[allow(needless_pass_by_value)]
 pub fn syncing<T>(_params: Params, mut _client: ValidatorClient<T>) -> Result<Value, Error>
 where
     T: MessageSender,

--- a/rpc/src/client.rs
+++ b/rpc/src/client.rs
@@ -244,7 +244,7 @@ impl<S: MessageSender> ValidatorClient<S> {
             .map_err(|error| Error::ParseError(format!("Error parsing response: {:?}", error)))
     }
 
-    pub fn send_transaction(&mut self, from: &str, txn: SethTransaction) -> Result<String, Error> {
+    pub fn send_transaction(&mut self, from: &str, txn: &SethTransaction) -> Result<String, Error> {
         let (batch, txn_signature) = self.make_batch(from, txn)?;
 
         let mut request = ClientBatchSubmitRequest::new();
@@ -262,7 +262,7 @@ impl<S: MessageSender> ValidatorClient<S> {
         }
     }
 
-    pub fn make_batch(&self, from: &str, txn: SethTransaction) -> Result<(Batch, String), Error> {
+    pub fn make_batch(&self, from: &str, txn: &SethTransaction) -> Result<(Batch, String), Error> {
         let payload = protobuf::Message::write_to_bytes(&txn.to_pb())
             .map_err(|error| Error::ParseError(format!("Error serializing payload: {:?}", error)))?;
 
@@ -491,7 +491,7 @@ impl<S: MessageSender> ValidatorClient<S> {
 
     pub fn get_entry(
         &mut self,
-        account_address: String,
+        account_address: &str,
         block: BlockKey,
     ) -> Result<Option<EvmEntry>, String> {
         let address = String::from(SETH_NS) + &account_address + "000000000000000000000000";
@@ -573,7 +573,7 @@ impl<S: MessageSender> ValidatorClient<S> {
 
     pub fn get_account(
         &mut self,
-        account_address: String,
+        account_address: &str,
         block: BlockKey,
     ) -> Result<Option<EvmStateAccount>, String> {
         self.get_entry(account_address, block)
@@ -582,7 +582,7 @@ impl<S: MessageSender> ValidatorClient<S> {
 
     pub fn get_storage(
         &mut self,
-        account_address: String,
+        account_address: &str,
         block: BlockKey,
     ) -> Result<Option<Vec<EvmStorage>>, String> {
         self.get_entry(account_address, block)
@@ -591,8 +591,8 @@ impl<S: MessageSender> ValidatorClient<S> {
 
     pub fn get_storage_at(
         &mut self,
-        account_address: String,
-        storage_address: String,
+        account_address: &str,
+        storage_address: &str,
         block: BlockKey,
     ) -> Result<Option<Vec<u8>>, String> {
         let storage = self.get_storage(account_address, block)?;

--- a/rpc/src/client.rs
+++ b/rpc/src/client.rs
@@ -610,11 +610,9 @@ impl<S: MessageSender> ValidatorClient<S> {
                         return Ok(Some(entry.value));
                     }
                 }
-                return Ok(None);
+                Ok(None)
             }
-            None => {
-                return Ok(None);
-            }
+            None => Ok(None),
         }
     }
 

--- a/rpc/src/client.rs
+++ b/rpc/src/client.rs
@@ -411,7 +411,7 @@ impl<S: MessageSender> ValidatorClient<S> {
             .map(SethReceipt::from_receipt_pb)
             .collect::<Result<Vec<SethReceipt>, Error>>()?;
         let mut seth_receipt_map = HashMap::with_capacity(seth_receipt_list.len());
-        for receipt in seth_receipt_list.into_iter() {
+        for receipt in seth_receipt_list {
             seth_receipt_map.insert(receipt.transaction_id.clone(), receipt);
         }
 
@@ -633,7 +633,7 @@ impl<S: MessageSender> ValidatorClient<S> {
                         return Err(String::from("Failed to decode position, invalid hex."));
                     }
                 };
-                for entry in storage.into_iter() {
+                for entry in storage {
                     if entry.key == position {
                         return Ok(Some(Vec::from(entry.value)));
                     }

--- a/rpc/src/client.rs
+++ b/rpc/src/client.rs
@@ -175,8 +175,8 @@ pub struct ValidatorClient<S: MessageSender> {
 impl<S: MessageSender> ValidatorClient<S> {
     pub fn new(sender: S, accounts: Vec<Account>) -> Self {
         ValidatorClient {
-            sender: sender,
-            accounts: accounts,
+            sender,
+            accounts,
             filters: FilterManager::new(),
         }
     }

--- a/rpc/src/client.rs
+++ b/rpc/src/client.rs
@@ -494,7 +494,7 @@ impl<S: MessageSender> ValidatorClient<S> {
         account_address: &str,
         block: BlockKey,
     ) -> Result<Option<EvmEntry>, String> {
-        let address = String::from(SETH_NS) + &account_address + "000000000000000000000000";
+        let address = String::from(SETH_NS) + account_address + "000000000000000000000000";
         let mut request = ClientStateGetRequest::new();
         request.set_address(address);
         match block {

--- a/rpc/src/client.rs
+++ b/rpc/src/client.rs
@@ -77,21 +77,15 @@ impl FromStr for BlockKey {
     type Err = BlockKeyParseError;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        if s == "latest" {
-            Ok(BlockKey::Latest)
-        } else if s == "earliest" {
-            Ok(BlockKey::Earliest)
-        } else if s == "pending" {
-            Err(BlockKeyParseError::Unsupported)
-        } else {
-            if s.len() < 3 {
-                Err(BlockKeyParseError::Invalid)
-            } else {
-                match u64::from_str_radix(&s[2..], 16) {
-                    Ok(num) => Ok(BlockKey::Number(num)),
-                    Err(_) => Err(BlockKeyParseError::Invalid),
-                }
-            }
+        match s {
+            "latest" => Ok(BlockKey::Latest),
+            "earliest" => Ok(BlockKey::Earliest),
+            "pending" => Err(BlockKeyParseError::Unsupported),
+            _ if s.len() < 3 => Err(BlockKeyParseError::Invalid),
+            _ => match u64::from_str_radix(&s[2..], 16) {
+                Ok(num) => Ok(BlockKey::Number(num)),
+                Err(_) => Err(BlockKeyParseError::Invalid),
+            },
         }
     }
 }

--- a/rpc/src/client.rs
+++ b/rpc/src/client.rs
@@ -397,8 +397,8 @@ impl<S: MessageSender> ValidatorClient<S> {
         &mut self,
         txn_key: &TransactionKey,
     ) -> Result<(Transaction, Option<Block>), Error> {
-        match txn_key {
-            &TransactionKey::Signature(ref txn_id) => {
+        match *txn_key {
+            TransactionKey::Signature(ref txn_id) => {
                 let mut request = ClientTransactionGetRequest::new();
                 request.set_transaction_id((*txn_id).clone());
                 let mut response: ClientTransactionGetResponse = self.send_request(
@@ -421,7 +421,7 @@ impl<S: MessageSender> ValidatorClient<S> {
                     }
                 }
             }
-            &TransactionKey::Index((ref index, ref block_key)) => {
+            TransactionKey::Index((ref index, ref block_key)) => {
                 let mut idx = *index;
                 let mut block = self.get_block((*block_key).clone())?;
                 for mut batch in block.take_batches().into_iter() {

--- a/rpc/src/filters.rs
+++ b/rpc/src/filters.rs
@@ -207,11 +207,7 @@ impl FilterManager {
     }
 
     pub fn get_filter(&mut self, filter_id: &FilterId) -> Option<FilterEntry> {
-        self.filters
-            .lock()
-            .unwrap()
-            .get(filter_id)
-            .map(|filter| filter.clone())
+        self.filters.lock().unwrap().get(filter_id).cloned()
     }
 
     pub fn update_latest_block(&mut self, filter_id: &FilterId, block_num: u64) -> bool {

--- a/rpc/src/filters.rs
+++ b/rpc/src/filters.rs
@@ -50,9 +50,7 @@ impl TopicFilter {
                 Ok(TopicFilter::Exactly(blob))
             }
             Value::Null => Ok(TopicFilter::All),
-            _ => {
-                return Err(RpcError::invalid_params("Invalid topic setting"));
-            }
+            _ => Err(RpcError::invalid_params("Invalid topic setting")),
         }
     }
     /// The topic passes this filter if:

--- a/rpc/src/filters.rs
+++ b/rpc/src/filters.rs
@@ -95,13 +95,10 @@ impl LogFilter {
 
         // Parse the address into a vec of strings
         let addresses = match filter.get("address") {
-            Some(&Value::Array(ref multiple)) => {
-                let addresses = multiple
-                    .iter()
-                    .map(|addr_val| transform::string_from_hex_value(addr_val))
-                    .collect::<Result<Vec<String>, RpcError>>()?;
-                addresses
-            }
+            Some(&Value::Array(ref multiple)) => multiple
+                .iter()
+                .map(|addr_val| transform::string_from_hex_value(addr_val))
+                .collect::<Result<Vec<String>, RpcError>>()?,
             Some(value) => {
                 let address = transform::string_from_hex_value(value)?;
                 vec![address]

--- a/rpc/src/filters.rs
+++ b/rpc/src/filters.rs
@@ -36,19 +36,19 @@ pub enum TopicFilter {
 
 impl TopicFilter {
     pub fn from_value(value: &Value) -> Result<Self, RpcError> {
-        match value {
-            &Value::Array(ref array) => {
+        match *value {
+            Value::Array(ref array) => {
                 let blobs = array
                     .iter()
                     .map(transform::string_from_hex_value)
                     .collect::<Result<Vec<String>, RpcError>>()?;
                 Ok(TopicFilter::OneOf(blobs))
             }
-            &Value::String(_) => {
+            Value::String(_) => {
                 let blob = transform::string_from_hex_value(value)?;
                 Ok(TopicFilter::Exactly(blob))
             }
-            &Value::Null => Ok(TopicFilter::All),
+            Value::Null => Ok(TopicFilter::All),
             _ => {
                 return Err(RpcError::invalid_params("Invalid topic setting"));
             }
@@ -59,10 +59,10 @@ impl TopicFilter {
     ///   2. The filter is Exactly and the topic and the filter are identitical
     ///   3. The filter is OneOf and the topic is with the filter's list of topics
     pub fn contains(&self, topic: &str) -> bool {
-        match self {
-            &TopicFilter::All => true,
-            &TopicFilter::Exactly(ref blob) => blob == topic,
-            &TopicFilter::OneOf(ref blobs) => blobs.contains(&String::from(topic)),
+        match *self {
+            TopicFilter::All => true,
+            TopicFilter::Exactly(ref blob) => blob == topic,
+            TopicFilter::OneOf(ref blobs) => blobs.contains(&String::from(topic)),
         }
     }
 }

--- a/rpc/src/filters.rs
+++ b/rpc/src/filters.rs
@@ -113,10 +113,10 @@ impl LogFilter {
         })?;
 
         Ok(LogFilter {
-            from_block: from_block,
-            to_block: to_block,
-            addresses: addresses,
-            topics: topics,
+            from_block,
+            to_block,
+            addresses,
+            topics,
         })
     }
 
@@ -220,7 +220,7 @@ impl FilterManager {
         block_num: u64,
     ) -> Option<FilterEntry> {
         let filter_entry = FilterEntry {
-            filter: filter,
+            filter,
             last_block_sent: block_num,
         };
         self.filters

--- a/rpc/src/filters.rs
+++ b/rpc/src/filters.rs
@@ -78,7 +78,7 @@ pub struct LogFilter {
 }
 
 impl LogFilter {
-    pub fn from_map(filter: Map<String, Value>) -> Result<Self, RpcError> {
+    pub fn from_map(filter: &Map<String, Value>) -> Result<Self, RpcError> {
         let from_block = match filter.get("fromBlock") {
             Some(s) => {
                 let s = transform::u64_from_hex_value(s)?;

--- a/rpc/src/filters.rs
+++ b/rpc/src/filters.rs
@@ -192,20 +192,20 @@ impl FilterManager {
 
     pub fn new_filter(&mut self, filter: Filter, block_num: u64) -> FilterId {
         let filter_id = self.id_ctr.fetch_add(1, Ordering::SeqCst);
-        self.set_filter(&filter_id, filter, block_num);
+        self.set_filter(filter_id, filter, block_num);
         filter_id
     }
 
-    pub fn remove_filter(&mut self, filter_id: &FilterId) -> Option<FilterEntry> {
-        self.filters.lock().unwrap().remove(filter_id)
+    pub fn remove_filter(&mut self, filter_id: FilterId) -> Option<FilterEntry> {
+        self.filters.lock().unwrap().remove(&filter_id)
     }
 
-    pub fn get_filter(&mut self, filter_id: &FilterId) -> Option<FilterEntry> {
-        self.filters.lock().unwrap().get(filter_id).cloned()
+    pub fn get_filter(&mut self, filter_id: FilterId) -> Option<FilterEntry> {
+        self.filters.lock().unwrap().get(&filter_id).cloned()
     }
 
-    pub fn update_latest_block(&mut self, filter_id: &FilterId, block_num: u64) -> bool {
-        if let Entry::Occupied(mut entry) = self.filters.lock().unwrap().entry(*filter_id) {
+    pub fn update_latest_block(&mut self, filter_id: FilterId, block_num: u64) -> bool {
+        if let Entry::Occupied(mut entry) = self.filters.lock().unwrap().entry(filter_id) {
             (*entry.get_mut()).last_block_sent = block_num;
             true
         } else {
@@ -215,7 +215,7 @@ impl FilterManager {
 
     pub fn set_filter(
         &mut self,
-        filter_id: &FilterId,
+        filter_id: FilterId,
         filter: Filter,
         block_num: u64,
     ) -> Option<FilterEntry> {
@@ -223,10 +223,7 @@ impl FilterManager {
             filter,
             last_block_sent: block_num,
         };
-        self.filters
-            .lock()
-            .unwrap()
-            .insert(*filter_id, filter_entry)
+        self.filters.lock().unwrap().insert(filter_id, filter_entry)
     }
 }
 

--- a/rpc/src/main.rs
+++ b/rpc/src/main.rs
@@ -76,7 +76,7 @@ fn main() {
         .unwrap_or("tcp://127.0.0.1:4004");
     let accounts: Vec<Account> = arg_matches
         .values_of_lossy("unlock")
-        .unwrap_or_else(|| Vec::new())
+        .unwrap_or_else(Vec::new)
         .iter()
         .map(|alias| abort_if_err(Account::load_from_alias(alias)))
         .collect();

--- a/rpc/src/main.rs
+++ b/rpc/src/main.rs
@@ -81,7 +81,7 @@ fn main() {
         .map(|alias| abort_if_err(Account::load_from_alias(alias)))
         .collect();
 
-    for account in accounts.iter() {
+    for account in &accounts {
         println!("{} unlocked: {}", account.alias(), account.address());
     }
 

--- a/rpc/src/requests.rs
+++ b/rpc/src/requests.rs
@@ -34,7 +34,7 @@ impl<T: MessageSender + Clone + Sync + Send + 'static> RequestExecutor<T> {
     pub fn new(client: ValidatorClient<T>) -> Self {
         RequestExecutor {
             pool: CpuPool::new_num_cpus(),
-            client: client,
+            client,
         }
     }
 

--- a/rpc/src/transactions.rs
+++ b/rpc/src/transactions.rs
@@ -14,6 +14,7 @@
  * limitations under the License.
  * ------------------------------------------------------------------------------
  */
+#![allow(unknown_lints)]
 
 use protobuf;
 
@@ -135,6 +136,7 @@ impl Transaction {
         }
     }
 
+    #[allow(wrong_self_convention)]
     pub fn from_addr(&self) -> String {
         public_key_to_address(&transform::hex_str_to_bytes(&self.signer_public_key).unwrap())
     }

--- a/rpc/src/transactions.rs
+++ b/rpc/src/transactions.rs
@@ -190,9 +190,9 @@ impl SethLog {
         let data: String = transform::bytes_to_hex_str(event.get_data());
 
         Ok(SethLog {
-            address: address,
-            topics: topics,
-            data: data,
+            address,
+            topics,
+            data,
         })
     }
 }
@@ -247,10 +247,10 @@ impl SethReceipt {
 
         Ok(SethReceipt {
             transaction_id: String::from(receipt.get_transaction_id()),
-            contract_address: contract_address,
-            gas_used: gas_used,
-            return_value: return_value,
-            logs: logs,
+            contract_address,
+            gas_used,
+            return_value,
+            logs,
         })
     }
 }

--- a/rpc/src/transactions.rs
+++ b/rpc/src/transactions.rs
@@ -60,20 +60,20 @@ impl SethTransaction {
 
     pub fn to_pb(&self) -> SethTrasactionPb {
         let mut txn = SethTrasactionPb::new();
-        match self {
-            &SethTransaction::CreateExternalAccount(ref inner) => {
+        match *self {
+            SethTransaction::CreateExternalAccount(ref inner) => {
                 txn.set_transaction_type(SethTransaction_TransactionType::CREATE_EXTERNAL_ACCOUNT);
                 txn.set_create_external_account(inner.clone());
             }
-            &SethTransaction::CreateContractAccount(ref inner) => {
+            SethTransaction::CreateContractAccount(ref inner) => {
                 txn.set_transaction_type(SethTransaction_TransactionType::CREATE_CONTRACT_ACCOUNT);
                 txn.set_create_contract_account(inner.clone());
             }
-            &SethTransaction::MessageCall(ref inner) => {
+            SethTransaction::MessageCall(ref inner) => {
                 txn.set_transaction_type(SethTransaction_TransactionType::MESSAGE_CALL);
                 txn.set_message_call(inner.clone());
             }
-            &SethTransaction::SetPermissions(ref inner) => {
+            SethTransaction::SetPermissions(ref inner) => {
                 txn.set_transaction_type(SethTransaction_TransactionType::SET_PERMISSIONS);
                 txn.set_set_permissions(inner.clone());
             }

--- a/rpc/src/transactions.rs
+++ b/rpc/src/transactions.rs
@@ -99,7 +99,7 @@ impl Transaction {
             .map_err(|_| Error::ParseError(String::from("Failed to parse header")))?;
         let inner: Option<SethTransaction> = protobuf::parse_from_bytes(&txn.payload)
             .map_err(|_| Error::ParseError(String::from("Failed to parse payload")))
-            .map(|seth_txn_pb| SethTransaction::try_from(seth_txn_pb))?;
+            .map(SethTransaction::try_from)?;
         match inner {
             Some(seth_txn) => Ok(Transaction {
                 signer_public_key: header.take_signer_public_key(),

--- a/rpc/src/transform.rs
+++ b/rpc/src/transform.rs
@@ -212,7 +212,7 @@ pub fn make_log_obj(
 }
 
 // -- Transaction --
-pub fn make_txn_obj(txn: Transaction, txn_idx: u64, block_id: &str, block_num: u64) -> Value {
+pub fn make_txn_obj(txn: &Transaction, txn_idx: u64, block_id: &str, block_num: u64) -> Value {
     let obj = make_txn_obj_no_block(txn);
     if let Value::Object(mut map) = obj {
         map.insert(String::from("blockHash"), hex_prefix(block_id));
@@ -224,7 +224,7 @@ pub fn make_txn_obj(txn: Transaction, txn_idx: u64, block_id: &str, block_num: u
     }
 }
 
-pub fn make_txn_obj_no_block(txn: Transaction) -> Value {
+pub fn make_txn_obj_no_block(txn: &Transaction) -> Value {
     let mut map = Map::with_capacity(11);
     map.insert(String::from("hash"), hex_prefix(&txn.hash()));
     map.insert(String::from("nonce"), num_to_hex(&txn.nonce()));

--- a/rpc/src/transform.rs
+++ b/rpc/src/transform.rs
@@ -38,7 +38,7 @@ pub fn hex_str_to_bytes(s: &str) -> Option<Vec<u8>> {
         })
         .collect();
 
-    return Some(decoded);
+    Some(decoded)
 }
 
 pub fn bytes_to_hex_str(b: &[u8]) -> String {

--- a/rpc/src/transform.rs
+++ b/rpc/src/transform.rs
@@ -116,7 +116,7 @@ where
     F: FnOnce(&Value) -> Result<T, Error>,
 {
     if let Some(value) = map.get(key) {
-        then(value).map(|v| Some(v))
+        then(value).map(Some)
     } else {
         Ok(None)
     }

--- a/rpc/src/transform.rs
+++ b/rpc/src/transform.rs
@@ -55,11 +55,11 @@ pub fn num_to_hex<T>(n: &T) -> Value
 where
     T: LowerHex,
 {
-    Value::String(String::from(format!("{:#x}", n)))
+    Value::String(format!("{:#x}", n))
 }
 
 pub fn hex_prefix(s: &str) -> Value {
-    Value::String(String::from(format!("0x{}", s)))
+    Value::String(format!("0x{}", s))
 }
 
 pub fn zerobytes(mut nbytes: usize) -> Value {

--- a/rpc/src/transform.rs
+++ b/rpc/src/transform.rs
@@ -81,10 +81,10 @@ where
 {
     value
         .as_str()
-        .ok_or_else(|| Error::invalid_params(format!("Not a string")))
+        .ok_or_else(|| Error::invalid_params(String::from("Not a string")))
         .and_then(|v| {
             v.get(2..)
-                .ok_or_else(|| Error::invalid_params(format!("Must have 0x")))
+                .ok_or_else(|| Error::invalid_params(String::from("Must have 0x")))
         })
         .and_then(then)
 }
@@ -98,7 +98,7 @@ pub fn u64_from_hex_value(value: &Value) -> Result<u64, Error> {
 
 pub fn bytes_from_hex_value(value: &Value) -> Result<Vec<u8>, Error> {
     from_hex_value_then(value, |s| {
-        hex_str_to_bytes(s).ok_or_else(|| Error::invalid_params(format!("Not valid hex",)))
+        hex_str_to_bytes(s).ok_or_else(|| Error::invalid_params(String::from("Not valid hex")))
     })
 }
 
@@ -139,7 +139,7 @@ pub fn get_array_from_map(map: &Map<String, Value>, key: &str) -> Result<Vec<Val
     if let Some(value) = map.get(key) {
         value
             .as_array()
-            .ok_or_else(|| Error::invalid_params(format!("Not an array")))
+            .ok_or_else(|| Error::invalid_params(String::from("Not an array")))
             .map(|a| a.clone())
     } else {
         Ok(Vec::new())


### PR DESCRIPTION
This PR goes through each clippy lint and adds a commit that fixes it. Particular attention should be paid to the `mutex_atomic` and `collapsible_if` lint fixes, as those were slightly less trivial than copy/pasting the clippy-suggested replacement like the other lint fixes.