### PR TITLE
Change default RPC return values

### DIFF
--- a/rpc/src/calls/account.rs
+++ b/rpc/src/calls/account.rs
@@ -83,9 +83,14 @@ where
     T: MessageSender,
 {
     info!("eth_getBalance");
-    get_account(params, client, |account| {
+    let balance = get_account(params, client, |account| {
         transform::num_to_hex(&account.balance)
-    })
+    });
+
+    match balance {
+        Ok(Value::Null) => Ok("0x0".into()),
+        other => other,
+    }
 }
 
 #[allow(needless_pass_by_value)]
@@ -123,9 +128,14 @@ where
     T: MessageSender,
 {
     info!("eth_getCode");
-    get_account(params, client, |account| {
+    let code = get_account(params, client, |account| {
         transform::hex_prefix(&transform::bytes_to_hex_str(&account.code))
-    })
+    });
+
+    match code {
+        Ok(Value::Null) => Ok("0x".into()),
+        other => other,
+    }
 }
 
 #[allow(needless_pass_by_value)]
@@ -134,9 +144,15 @@ where
     T: MessageSender,
 {
     info!("eth_getTransactionCount");
-    get_account(params, client, |account| {
+    let nonce = get_account(params, client, |account| {
         transform::num_to_hex(&account.nonce)
-    })
+    });
+
+    // The transaction count of a non-existent address is 0, not null
+    match nonce {
+        Ok(Value::Null) => Ok("0x0".into()),
+        other => other,
+    }
 }
 
 #[allow(needless_pass_by_value)]

--- a/rpc/src/transform.rs
+++ b/rpc/src/transform.rs
@@ -168,7 +168,10 @@ pub fn make_txn_receipt_obj(
     map.insert(String::from("gasUsed"), num_to_hex(&receipt.gas_used));
     map.insert(
         String::from("contractAddress"),
-        hex_prefix(&receipt.contract_address),
+        match receipt.contract_address.len() {
+            0 => Value::Null,
+            _ => hex_prefix(&receipt.contract_address),
+        },
     );
     map.insert(
         String::from("returnValue"),

--- a/rpc/tests/test_seth_rpc.py
+++ b/rpc/tests/test_seth_rpc.py
@@ -340,7 +340,7 @@ class SethRpcTest(unittest.TestCase):
 
         self._send_state_no_resource(msg)
         result = self.rpc.get_result()
-        self.assertIsNone(result)
+        self.assertEqual(result, "0x0")
 
     def test_get_code(self):
         """Test that an account's code is retrieved correctly."""
@@ -378,7 +378,7 @@ class SethRpcTest(unittest.TestCase):
 
         self._send_state_no_resource(msg)
         result = self.rpc.get_result()
-        self.assertIsNone(result)
+        self.assertEqual(result, "0x")
 
     def test_get_storage_at(self):
         """Test that an account's storage is retrieved correctly."""


### PR DESCRIPTION
The transaction count and balance should be 0 for non-existent accounts, not null. Additionally, the code should be blank.

See https://github.com/ethereum/go-ethereum/blob/d926bf2c7e3182d694c15829a37a0ca7331cd03c/core/state/statedb.go#L199 for prior art.

Signed-off-by: Kenneth Koski <knkski@bitwise.io>