### PR TITLE
Use vec![] in get_method_list

### DIFF
--- a/rpc/src/calls/account.rs
+++ b/rpc/src/calls/account.rs
@@ -30,18 +30,13 @@ pub fn get_method_list<T>() -> Vec<(String, RequestHandler<T>)>
 where
     T: MessageSender,
 {
-    let mut methods: Vec<(String, RequestHandler<T>)> = Vec::new();
-
-    methods.push((String::from("eth_getBalance"), get_balance));
-    methods.push((String::from("eth_getStorageAt"), get_storage_at));
-    methods.push((String::from("eth_getCode"), get_code));
-    methods.push((String::from("eth_accounts"), accounts));
-    methods.push((
-        String::from("eth_getTransactionCount"),
-        get_transaction_count,
-    ));
-
-    methods
+    vec![
+        ("eth_getBalance".into(), get_balance),
+        ("eth_getStorageAt".into(), get_storage_at),
+        ("eth_getCode".into(), get_code),
+        ("eth_accounts".into(), accounts),
+        ("eth_getTransactionCount".into(), get_transaction_count),
+    ]
 }
 
 fn validate_block_key(block: &str) -> Result<BlockKey, Error> {

--- a/rpc/src/calls/block.rs
+++ b/rpc/src/calls/block.rs
@@ -35,21 +35,19 @@ pub fn get_method_list<T>() -> Vec<(String, RequestHandler<T>)>
 where
     T: MessageSender,
 {
-    let mut methods: Vec<(String, RequestHandler<T>)> = Vec::new();
-
-    methods.push((String::from("eth_blockNumber"), block_number));
-    methods.push((String::from("eth_getBlockByHash"), get_block_by_hash));
-    methods.push((String::from("eth_getBlockByNumber"), get_block_by_number));
-    methods.push((
-        String::from("eth_getBlockTransactionCountByHash"),
-        get_block_transaction_count_by_hash,
-    ));
-    methods.push((
-        String::from("eth_getBlockTransactionCountByNumber"),
-        get_block_transaction_count_by_number,
-    ));
-
-    methods
+    vec![
+        ("eth_blockNumber".into(), block_number),
+        ("eth_getBlockByHash".into(), get_block_by_hash),
+        ("eth_getBlockByNumber".into(), get_block_by_number),
+        (
+            "eth_getBlockTransactionCountByHash".into(),
+            get_block_transaction_count_by_hash,
+        ),
+        (
+            "eth_getBlockTransactionCountByNumber".into(),
+            get_block_transaction_count_by_number,
+        ),
+    ]
 }
 
 // Return the block number of the current chain head, in hex, as a string

--- a/rpc/src/calls/logs.rs
+++ b/rpc/src/calls/logs.rs
@@ -37,20 +37,18 @@ pub fn get_method_list<T>() -> Vec<(String, RequestHandler<T>)>
 where
     T: MessageSender,
 {
-    let mut methods: Vec<(String, RequestHandler<T>)> = Vec::new();
-
-    methods.push((String::from("eth_newFilter"), new_filter));
-    methods.push((String::from("eth_newBlockFilter"), new_block_filter));
-    methods.push((
-        String::from("eth_newPendingTransactionFilter"),
-        new_pending_transaction_filter,
-    ));
-    methods.push((String::from("eth_uninstallFilter"), uninstall_filter));
-    methods.push((String::from("eth_getFilterChanges"), get_filter_changes));
-    methods.push((String::from("eth_getFilterLogs"), get_filter_logs));
-    methods.push((String::from("eth_getLogs"), get_logs));
-
-    methods
+    vec![
+        ("eth_newFilter".into(), new_filter),
+        ("eth_newBlockFilter".into(), new_block_filter),
+        (
+            "eth_newPendingTransactionFilter".into(),
+            new_pending_transaction_filter,
+        ),
+        ("eth_uninstallFilter".into(), uninstall_filter),
+        ("eth_getFilterChanges".into(), get_filter_changes),
+        ("eth_getFilterLogs".into(), get_filter_logs),
+        ("eth_getLogs".into(), get_logs),
+    ]
 }
 
 #[allow(needless_pass_by_value)]

--- a/rpc/src/calls/network.rs
+++ b/rpc/src/calls/network.rs
@@ -28,13 +28,11 @@ pub fn get_method_list<T>() -> Vec<(String, RequestHandler<T>)>
 where
     T: MessageSender,
 {
-    let mut methods: Vec<(String, RequestHandler<T>)> = Vec::new();
-
-    methods.push((String::from("net_version"), version));
-    methods.push((String::from("net_peerCount"), peer_count));
-    methods.push((String::from("net_listening"), listening));
-
-    methods
+    vec![
+        ("net_version".into(), version),
+        ("net_peerCount".into(), peer_count),
+        ("net_listening".into(), listening),
+    ]
 }
 
 // Version refers to the particular network this JSON-RPC client is connected to

--- a/rpc/src/calls/transaction.rs
+++ b/rpc/src/calls/transaction.rs
@@ -39,33 +39,25 @@ pub fn get_method_list<T>() -> Vec<(String, RequestHandler<T>)>
 where
     T: MessageSender,
 {
-    let mut methods: Vec<(String, RequestHandler<T>)> = Vec::new();
-
-    methods.push((String::from("eth_sendTransaction"), send_transaction));
-    methods.push((String::from("eth_sendRawTransaction"), send_raw_transaction));
-    methods.push((
-        String::from("eth_getTransactionByHash"),
-        get_transaction_by_hash,
-    ));
-    methods.push((
-        String::from("eth_getTransactionByBlockHashAndIndex"),
-        get_transaction_by_block_hash_and_index,
-    ));
-    methods.push((
-        String::from("eth_getTransactionByBlockNumberAndIndex"),
-        get_transaction_by_block_number_and_index,
-    ));
-    methods.push((
-        String::from("eth_getTransactionReceipt"),
-        get_transaction_receipt,
-    ));
-    methods.push((String::from("eth_gasPrice"), gas_price));
-    methods.push((String::from("eth_estimateGas"), estimate_gas));
-    methods.push((String::from("eth_sign"), sign));
-    methods.push((String::from("eth_call"), call));
-    methods.push((String::from("eth_syncing"), syncing));
-
-    methods
+    vec![
+        ("eth_call".into(), call),
+        ("eth_estimateGas".into(), estimate_gas),
+        ("eth_gasPrice".into(), gas_price),
+        (
+            "eth_getTransactionByBlockHashAndIndex".into(),
+            get_transaction_by_block_hash_and_index,
+        ),
+        (
+            "eth_getTransactionByBlockNumberAndIndex".into(),
+            get_transaction_by_block_number_and_index,
+        ),
+        ("eth_getTransactionByHash".into(), get_transaction_by_hash),
+        ("eth_getTransactionReceipt".into(), get_transaction_receipt),
+        ("eth_sendRawTransaction".into(), send_raw_transaction),
+        ("eth_sendTransaction".into(), send_transaction),
+        ("eth_sign".into(), sign),
+        ("eth_syncing".into(), syncing),
+    ]
 }
 
 #[allow(needless_pass_by_value)]


### PR DESCRIPTION
Using the `vec![]` shorthand makes `get_method_list` more readable

Signed-off-by: Kenneth Koski <knkski@bitwise.io>