### PR TITLE
Remove mut requirement on ValidatorClient

### DIFF
--- a/rpc/src/calls/account.rs
+++ b/rpc/src/calls/account.rs
@@ -94,7 +94,7 @@ where
 }
 
 #[allow(needless_pass_by_value)]
-pub fn get_storage_at<T>(params: Params, mut client: ValidatorClient<T>) -> Result<Value, Error>
+pub fn get_storage_at<T>(params: Params, client: ValidatorClient<T>) -> Result<Value, Error>
 where
     T: MessageSender,
 {
@@ -156,7 +156,7 @@ where
 }
 
 #[allow(needless_pass_by_value)]
-fn get_account<T, F>(params: Params, mut client: ValidatorClient<T>, f: F) -> Result<Value, Error>
+fn get_account<T, F>(params: Params, client: ValidatorClient<T>, f: F) -> Result<Value, Error>
 where
     T: MessageSender,
     F: Fn(EvmStateAccount) -> Value,

--- a/rpc/src/calls/block.rs
+++ b/rpc/src/calls/block.rs
@@ -54,7 +54,7 @@ where
 
 // Return the block number of the current chain head, in hex, as a string
 #[allow(needless_pass_by_value)]
-pub fn block_number<T>(_params: Params, mut client: ValidatorClient<T>) -> Result<Value, Error>
+pub fn block_number<T>(_params: Params, client: ValidatorClient<T>) -> Result<Value, Error>
 where
     T: MessageSender,
 {
@@ -77,7 +77,7 @@ where
 fn get_block_obj<T>(
     block_key: BlockKey,
     full: bool,
-    mut client: ValidatorClient<T>,
+    client: ValidatorClient<T>,
 ) -> Result<Value, Error>
 where
     T: MessageSender,
@@ -168,7 +168,7 @@ where
 
 fn get_block_transaction_count<T>(
     block_key: BlockKey,
-    mut client: ValidatorClient<T>,
+    client: ValidatorClient<T>,
 ) -> Result<Value, Error>
 where
     T: MessageSender,

--- a/rpc/src/calls/logs.rs
+++ b/rpc/src/calls/logs.rs
@@ -54,7 +54,7 @@ where
 }
 
 #[allow(needless_pass_by_value)]
-pub fn new_filter<T>(params: Params, mut client: ValidatorClient<T>) -> Result<Value, Error>
+pub fn new_filter<T>(params: Params, client: ValidatorClient<T>) -> Result<Value, Error>
 where
     T: MessageSender,
 {
@@ -77,7 +77,7 @@ where
 }
 
 #[allow(needless_pass_by_value)]
-pub fn new_block_filter<T>(_params: Params, mut client: ValidatorClient<T>) -> Result<Value, Error>
+pub fn new_block_filter<T>(_params: Params, client: ValidatorClient<T>) -> Result<Value, Error>
 where
     T: MessageSender,
 {
@@ -93,7 +93,7 @@ where
 #[allow(needless_pass_by_value)]
 pub fn new_pending_transaction_filter<T>(
     _params: Params,
-    mut client: ValidatorClient<T>,
+    client: ValidatorClient<T>,
 ) -> Result<Value, Error>
 where
     T: MessageSender,
@@ -110,7 +110,7 @@ where
 }
 
 #[allow(needless_pass_by_value)]
-pub fn uninstall_filter<T>(params: Params, mut client: ValidatorClient<T>) -> Result<Value, Error>
+pub fn uninstall_filter<T>(params: Params, client: ValidatorClient<T>) -> Result<Value, Error>
 where
     T: MessageSender,
 {
@@ -128,7 +128,7 @@ where
 }
 
 #[allow(needless_pass_by_value)]
-pub fn get_filter_changes<T>(params: Params, mut client: ValidatorClient<T>) -> Result<Value, Error>
+pub fn get_filter_changes<T>(params: Params, client: ValidatorClient<T>) -> Result<Value, Error>
 where
     T: MessageSender,
 {
@@ -179,7 +179,7 @@ where
         Filter::Log(log_filter) => {
             let mut all_logs = Vec::new();
             for &(_, ref block) in &blocks {
-                let logs = get_logs_from_block_and_filter(&mut client, block, &log_filter)?;
+                let logs = get_logs_from_block_and_filter(&client, block, &log_filter)?;
                 all_logs.extend(logs.into_iter());
             }
             all_logs
@@ -196,7 +196,7 @@ where
 }
 
 #[allow(needless_pass_by_value)]
-pub fn get_filter_logs<T>(params: Params, mut client: ValidatorClient<T>) -> Result<Value, Error>
+pub fn get_filter_logs<T>(params: Params, client: ValidatorClient<T>) -> Result<Value, Error>
 where
     T: MessageSender,
 {
@@ -214,7 +214,7 @@ where
         .ok_or_else(|| Error::invalid_params(format!("Unknown filter id: {}", filter_id)))?;
 
     if let Filter::Log(log_filter) = filter {
-        get_logs_from_filter(&mut client, &log_filter)
+        get_logs_from_filter(&client, &log_filter)
     } else {
         Err(Error::invalid_params(format!(
             "Filter {} is not a log filter",
@@ -224,7 +224,7 @@ where
 }
 
 #[allow(needless_pass_by_value)]
-pub fn get_logs<T>(params: Params, mut client: ValidatorClient<T>) -> Result<Value, Error>
+pub fn get_logs<T>(params: Params, client: ValidatorClient<T>) -> Result<Value, Error>
 where
     T: MessageSender,
 {
@@ -234,11 +234,11 @@ where
         .map_err(|_| Error::invalid_params("Takes [filter: OBJECT]"))?;
     let log_filter = LogFilter::from_map(&filter)?;
 
-    get_logs_from_filter(&mut client, &log_filter)
+    get_logs_from_filter(&client, &log_filter)
 }
 
 fn get_logs_from_filter<T>(
-    mut client: &mut ValidatorClient<T>,
+    client: &ValidatorClient<T>,
     log_filter: &LogFilter,
 ) -> Result<Value, Error>
 where
@@ -254,7 +254,7 @@ where
                 Error::internal_error()
             })?;
 
-            let logs = get_logs_from_block_and_filter(&mut client, &block, &log_filter)?;
+            let logs = get_logs_from_block_and_filter(client, &block, &log_filter)?;
             Ok(Value::Array(logs))
         }
         // Request for logs from a block to the latest block
@@ -265,7 +265,7 @@ where
                 match client.get_block(BlockKey::Number(block_index)) {
                     Ok(block) => {
                         let logs =
-                            get_logs_from_block_and_filter(&mut client, &block, &log_filter)?;
+                            get_logs_from_block_and_filter(client, &block, &log_filter)?;
                         all_logs.extend(logs.into_iter());
                     }
                     Err(ClientError::NoResource) => {
@@ -287,7 +287,7 @@ where
                 match client.get_block(BlockKey::Number(block_index)) {
                     Ok(block) => {
                         let logs =
-                            get_logs_from_block_and_filter(&mut client, &block, &log_filter)?;
+                            get_logs_from_block_and_filter(client, &block, &log_filter)?;
                         all_logs.extend(logs.into_iter());
                     }
                     Err(ClientError::NoResource) => {
@@ -308,7 +308,7 @@ where
 }
 
 fn get_logs_from_block_and_filter<T>(
-    client: &mut ValidatorClient<T>,
+    client: &ValidatorClient<T>,
     block: &Block,
     log_filter: &LogFilter,
 ) -> Result<Vec<Value>, Error>

--- a/rpc/src/calls/network.rs
+++ b/rpc/src/calls/network.rs
@@ -39,7 +39,7 @@ where
 
 // Version refers to the particular network this JSON-RPC client is connected to
 #[allow(needless_pass_by_value)]
-pub fn version<T>(_params: Params, mut _client: ValidatorClient<T>) -> Result<Value, Error>
+pub fn version<T>(_params: Params, _client: ValidatorClient<T>) -> Result<Value, Error>
 where
     T: MessageSender,
 {
@@ -49,7 +49,7 @@ where
 
 // Return the number of actual Sawtooth peers
 #[allow(needless_pass_by_value)]
-pub fn peer_count<T>(_params: Params, mut client: ValidatorClient<T>) -> Result<Value, Error>
+pub fn peer_count<T>(_params: Params, client: ValidatorClient<T>) -> Result<Value, Error>
 where
     T: MessageSender,
 {
@@ -64,7 +64,7 @@ where
 
 // Return whether we are listening for connections, which is always true
 #[allow(needless_pass_by_value)]
-pub fn listening<T>(_params: Params, mut _client: ValidatorClient<T>) -> Result<Value, Error>
+pub fn listening<T>(_params: Params, _client: ValidatorClient<T>) -> Result<Value, Error>
 where
     T: MessageSender,
 {

--- a/rpc/src/calls/transaction.rs
+++ b/rpc/src/calls/transaction.rs
@@ -69,7 +69,7 @@ where
 }
 
 #[allow(needless_pass_by_value)]
-pub fn send_transaction<T>(params: Params, mut client: ValidatorClient<T>) -> Result<Value, Error>
+pub fn send_transaction<T>(params: Params, client: ValidatorClient<T>) -> Result<Value, Error>
 where
     T: MessageSender,
 {
@@ -255,7 +255,7 @@ where
 }
 
 fn get_transaction<T>(
-    mut client: ValidatorClient<T>,
+    client: ValidatorClient<T>,
     txn_key: &TransactionKey,
 ) -> Result<Value, Error>
 where
@@ -323,7 +323,7 @@ where
 #[allow(needless_pass_by_value)]
 pub fn get_transaction_receipt<T>(
     params: Params,
-    mut client: ValidatorClient<T>,
+    client: ValidatorClient<T>,
 ) -> Result<Value, Error>
 where
     T: MessageSender,

--- a/rpc/src/client.rs
+++ b/rpc/src/client.rs
@@ -179,7 +179,7 @@ impl<S: MessageSender> ValidatorClient<S> {
         &self.accounts
     }
 
-    pub fn request<T, U>(&mut self, msg_type: Message_MessageType, msg: &T) -> Result<U, String>
+    pub fn request<T, U>(&self, msg_type: Message_MessageType, msg: &T) -> Result<U, String>
     where
         T: protobuf::Message,
         U: protobuf::Message,
@@ -222,7 +222,7 @@ impl<S: MessageSender> ValidatorClient<S> {
         Ok(response)
     }
 
-    pub fn send_request<T, U>(&mut self, msg_type: Message_MessageType, msg: &T) -> Result<U, Error>
+    pub fn send_request<T, U>(&self, msg_type: Message_MessageType, msg: &T) -> Result<U, Error>
     where
         T: protobuf::Message,
         U: protobuf::Message,
@@ -239,7 +239,7 @@ impl<S: MessageSender> ValidatorClient<S> {
             .map_err(|error| Error::ParseError(format!("Error parsing response: {:?}", error)))
     }
 
-    pub fn send_transaction(&mut self, from: &str, txn: &SethTransaction) -> Result<String, Error> {
+    pub fn send_transaction(&self, from: &str, txn: &SethTransaction) -> Result<String, Error> {
         let (batch, txn_signature) = self.make_batch(from, txn)?;
 
         let mut request = ClientBatchSubmitRequest::new();
@@ -322,7 +322,7 @@ impl<S: MessageSender> ValidatorClient<S> {
     }
 
     pub fn get_receipts_from_block(
-        &mut self,
+        &self,
         block: &Block,
     ) -> Result<HashMap<String, SethReceipt>, String> {
         let batches = &block.batches;
@@ -353,7 +353,7 @@ impl<S: MessageSender> ValidatorClient<S> {
     }
 
     pub fn get_receipts(
-        &mut self,
+        &self,
         transaction_ids: &[String],
     ) -> Result<HashMap<String, SethReceipt>, Error> {
         let mut request = ClientReceiptGetRequest::new();
@@ -391,7 +391,7 @@ impl<S: MessageSender> ValidatorClient<S> {
     }
 
     pub fn get_transaction_and_block(
-        &mut self,
+        &self,
         txn_key: &TransactionKey,
     ) -> Result<(Transaction, Option<Block>), Error> {
         match *txn_key {
@@ -435,7 +435,7 @@ impl<S: MessageSender> ValidatorClient<S> {
         }
     }
 
-    pub fn get_block(&mut self, block_key: BlockKey) -> Result<Block, Error> {
+    pub fn get_block(&self, block_key: BlockKey) -> Result<Block, Error> {
         let response: ClientBlockGetResponse;
         match block_key {
             BlockKey::Signature(block_id) => {
@@ -487,7 +487,7 @@ impl<S: MessageSender> ValidatorClient<S> {
     }
 
     pub fn get_entry(
-        &mut self,
+        &self,
         account_address: &str,
         block: BlockKey,
     ) -> Result<Option<EvmEntry>, String> {
@@ -569,7 +569,7 @@ impl<S: MessageSender> ValidatorClient<S> {
     }
 
     pub fn get_account(
-        &mut self,
+        &self,
         account_address: &str,
         block: BlockKey,
     ) -> Result<Option<EvmStateAccount>, String> {
@@ -578,7 +578,7 @@ impl<S: MessageSender> ValidatorClient<S> {
     }
 
     pub fn get_storage(
-        &mut self,
+        &self,
         account_address: &str,
         block: BlockKey,
     ) -> Result<Option<Vec<EvmStorage>>, String> {
@@ -587,7 +587,7 @@ impl<S: MessageSender> ValidatorClient<S> {
     }
 
     pub fn get_storage_at(
-        &mut self,
+        &self,
         account_address: &str,
         storage_address: &str,
         block: BlockKey,
@@ -613,7 +613,7 @@ impl<S: MessageSender> ValidatorClient<S> {
         }
     }
 
-    pub fn get_current_block(&mut self) -> Result<Block, Error> {
+    pub fn get_current_block(&self) -> Result<Block, Error> {
         let mut paging = ClientPagingControls::new();
         paging.set_limit(1);
         let mut request = ClientBlockListRequest::new();
@@ -626,7 +626,7 @@ impl<S: MessageSender> ValidatorClient<S> {
         Ok(block.clone())
     }
 
-    pub fn get_current_block_number(&mut self) -> Result<u64, Error> {
+    pub fn get_current_block_number(&self) -> Result<u64, Error> {
         let block = self.get_current_block()?;
         let block_header: BlockHeader =
             protobuf::parse_from_bytes(&block.header).map_err(|error| {
@@ -635,7 +635,7 @@ impl<S: MessageSender> ValidatorClient<S> {
         Ok(block_header.block_num)
     }
 
-    pub fn get_blocks_since(&mut self, since: u64) -> Result<Vec<(u64, Block)>, Error> {
+    pub fn get_blocks_since(&self, since: u64) -> Result<Vec<(u64, Block)>, Error> {
         let block = self.get_current_block()?;
         let block_header: BlockHeader =
             protobuf::parse_from_bytes(&block.header).map_err(|error| {
@@ -661,7 +661,7 @@ impl<S: MessageSender> ValidatorClient<S> {
         Ok(blocks)
     }
 
-    fn block_num_to_state_root(&mut self, block_num: u64) -> Result<String, Error> {
+    fn block_num_to_state_root(&self, block_num: u64) -> Result<String, Error> {
         self.get_block(BlockKey::Number(block_num))
             .and_then(|block| {
                 protobuf::parse_from_bytes(&block.header)
@@ -671,7 +671,7 @@ impl<S: MessageSender> ValidatorClient<S> {
             })
     }
 
-    fn block_id_to_state_root(&mut self, block_id: String) -> Result<String, Error> {
+    fn block_id_to_state_root(&self, block_id: String) -> Result<String, Error> {
         self.get_block(BlockKey::Signature(block_id))
             .and_then(|block| {
                 protobuf::parse_from_bytes(&block.header)
@@ -681,7 +681,7 @@ impl<S: MessageSender> ValidatorClient<S> {
             })
     }
 
-    fn transaction_to_state_root(&mut self, transaction_id: String) -> Result<String, Error> {
+    fn transaction_to_state_root(&self, transaction_id: String) -> Result<String, Error> {
         self.get_block(BlockKey::Transaction(transaction_id))
             .and_then(|block| {
                 protobuf::parse_from_bytes(&block.header)
@@ -691,7 +691,7 @@ impl<S: MessageSender> ValidatorClient<S> {
             })
     }
 
-    pub fn get_peers(&mut self) -> Result<usize, Error> {
+    pub fn get_peers(&self) -> Result<usize, Error> {
         let request = ClientPeersGetRequest::new();
         let response: ClientPeersGetResponse =
             self.send_request(Message_MessageType::CLIENT_PEERS_GET_REQUEST, &request)?;

--- a/rpc/src/filters.rs
+++ b/rpc/src/filters.rs
@@ -190,21 +190,21 @@ impl FilterManager {
         }
     }
 
-    pub fn new_filter(&mut self, filter: Filter, block_num: u64) -> FilterId {
+    pub fn new_filter(&self, filter: Filter, block_num: u64) -> FilterId {
         let filter_id = self.id_ctr.fetch_add(1, Ordering::SeqCst);
         self.set_filter(filter_id, filter, block_num);
         filter_id
     }
 
-    pub fn remove_filter(&mut self, filter_id: FilterId) -> Option<FilterEntry> {
+    pub fn remove_filter(&self, filter_id: FilterId) -> Option<FilterEntry> {
         self.filters.lock().unwrap().remove(&filter_id)
     }
 
-    pub fn get_filter(&mut self, filter_id: FilterId) -> Option<FilterEntry> {
+    pub fn get_filter(&self, filter_id: FilterId) -> Option<FilterEntry> {
         self.filters.lock().unwrap().get(&filter_id).cloned()
     }
 
-    pub fn update_latest_block(&mut self, filter_id: FilterId, block_num: u64) -> bool {
+    pub fn update_latest_block(&self, filter_id: FilterId, block_num: u64) -> bool {
         if let Entry::Occupied(mut entry) = self.filters.lock().unwrap().entry(filter_id) {
             (*entry.get_mut()).last_block_sent = block_num;
             true
@@ -214,7 +214,7 @@ impl FilterManager {
     }
 
     pub fn set_filter(
-        &mut self,
+        &self,
         filter_id: FilterId,
         filter: Filter,
         block_num: u64,


### PR DESCRIPTION
The zmq library we use for sending messages doesn't actually require a mutable reference for sending and replying. This PR changes the `&mut self` references to just `&self`.

Relies on https://github.com/hyperledger/sawtooth-core/pull/1834 being merged.

Signed-off-by: Kenneth Koski <knkski@bitwise.io>