### PR TITLE
Fix build.rs for breaking protoc-rust change

### DIFF
--- a/rpc/build.rs
+++ b/rpc/build.rs
@@ -37,9 +37,7 @@ fn main() {
             .map(|a| a.as_ref())
             .collect::<Vec<&str>>(),
         includes: &["src", "../protos"],
-        customize: Customize {
-            ..Default::default()
-        },
+        customize: Customize::default(),
     }).expect("unable to run protoc");
 }
 


### PR DESCRIPTION
..Default::default() accesses a now non-public member, whereas
Customize::default() is clearer.

Signed-off-by: Boyd Johnson <bjohnson@bitwise.io>

This PR depends on the sdk pr being merged: https://github.com/hyperledger/sawtooth-core/pull/1891.