### PR TITLE
Add dockerfiles for pushing to Docker Hub

### DIFF
--- a/ci/sawtooth-seth-cli
+++ b/ci/sawtooth-seth-cli
@@ -1,0 +1,36 @@
+# Copyright 2018 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ------------------------------------------------------------------------------
+
+# Description:
+#   Builds an image with the Sawtooth Seth CLI package installed from
+#   the Sawtooth Package Repository.
+
+FROM ubuntu:xenial
+
+RUN apt-get update \
+ && apt-get install gnupg -y
+
+LABEL "install-type"="repo"
+
+RUN echo "deb [arch=amd64] http://repo.sawtooth.me/ubuntu/bumper/nightly xenial universe" >> /etc/apt/sources.list \
+ && (apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 8AA7AF1F1091A5FD \
+ || apt-key adv --keyserver hkp://p80.pool.sks-keyservers.net:80 --recv-keys 8AA7AF1F1091A5FD) \
+ && apt-get update \
+ && apt-get install -y -q \
+    sawtooth-seth-cli \
+ && apt-get clean \
+ && rm -rf /var/lib/apt/lists/*
+
+CMD ["seth"]

--- a/ci/sawtooth-seth-cli-go
+++ b/ci/sawtooth-seth-cli-go
@@ -1,0 +1,36 @@
+# Copyright 2018 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ------------------------------------------------------------------------------
+
+# Description:
+#   Builds an image with the Sawtooth Seth CLI (Go) package installed from
+#   the Sawtooth Package Repository.
+
+FROM ubuntu:xenial
+
+RUN apt-get update \
+ && apt-get install gnupg -y
+
+LABEL "install-type"="repo"
+
+RUN echo "deb [arch=amd64] http://repo.sawtooth.me/ubuntu/bumper/nightly xenial universe" >> /etc/apt/sources.list \
+ && (apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 8AA7AF1F1091A5FD \
+ || apt-key adv --keyserver hkp://p80.pool.sks-keyservers.net:80 --recv-keys 8AA7AF1F1091A5FD) \
+ && apt-get update \
+ && apt-get install -y -q \
+    sawtooth-seth-cli-go \
+ && apt-get clean \
+ && rm -rf /var/lib/apt/lists/*
+
+CMD ["seth"]

--- a/ci/sawtooth-seth-rpc
+++ b/ci/sawtooth-seth-rpc
@@ -1,0 +1,38 @@
+# Copyright 2018 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ------------------------------------------------------------------------------
+
+# Description:
+#   Builds an image with the Sawtooth Seth RPC package installed from
+#   the Sawtooth Package Repository.
+
+FROM ubuntu:xenial
+
+RUN apt-get update \
+ && apt-get install gnupg -y
+
+LABEL "install-type"="repo"
+
+RUN echo "deb [arch=amd64] http://repo.sawtooth.me/ubuntu/bumper/nightly xenial universe" >> /etc/apt/sources.list \
+ && (apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 8AA7AF1F1091A5FD \
+ || apt-key adv --keyserver hkp://p80.pool.sks-keyservers.net:80 --recv-keys 8AA7AF1F1091A5FD) \
+ && apt-get update \
+ && apt-get install -y -q \
+    sawtooth-seth-rpc \
+ && apt-get clean \
+ && rm -rf /var/lib/apt/lists/*
+
+EXPOSE 3030/tcp
+
+CMD ["seth-rpc", "-vv"]

--- a/ci/sawtooth-seth-tp
+++ b/ci/sawtooth-seth-tp
@@ -1,0 +1,38 @@
+# Copyright 2018 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ------------------------------------------------------------------------------
+
+# Description:
+#   Builds an image with the Sawtooth Seth TP package installed from
+#   the Sawtooth Package Repository.
+
+FROM ubuntu:xenial
+
+RUN apt-get update \
+ && apt-get install gnupg -y
+
+LABEL "install-type"="repo"
+
+RUN echo "deb [arch=amd64] http://repo.sawtooth.me/ubuntu/bumper/nightly xenial universe" >> /etc/apt/sources.list \
+ && (apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 8AA7AF1F1091A5FD \
+ || apt-key adv --keyserver hkp://p80.pool.sks-keyservers.net:80 --recv-keys 8AA7AF1F1091A5FD) \
+ && apt-get update \
+ && apt-get install -y -q \
+    sawtooth-seth-tp \
+ && apt-get clean \
+ && rm -rf /var/lib/apt/lists/*
+
+EXPOSE 4004/tcp
+
+CMD ["seth-tp", "-vv"]


### PR DESCRIPTION
Adds dockerfiles suitable for publishing the various Sawtooth Seth packages to hub.docker.com for public consumption.

Signed-off-by: Kenneth Koski <knkski@bitwise.io>