### PR TITLE
Fix docker ignore

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -20,8 +20,8 @@
 
 # Auto-generated protobuf
 /common/src/protobuf
-/*/src/messages/*.rs
-!/*/src/messages/mod.rs
+**/src/messages/*.rs
+!**/src/messages/mod.rs
 /rpc/tests/protobuf/
 
 # Don't lock dependencies


### PR DESCRIPTION
Prior to this change on my system the seth-rpc image seemed to ignore the entire contents of `rpc/src/messages`, causing a build error, as `mod.rs` could not be found. This may only be an issue on docker 18.06.1-ce however, as it doesn't seem to reproduce on Jenkins.