### PR TITLE
Git clone can hang from within Dockerfile without a tty/stdin

### DIFF
--- a/docker-compose-installed.yaml
+++ b/docker-compose-installed.yaml
@@ -65,6 +65,8 @@ services:
       dockerfile: ./processor/Dockerfile-installed
       args:
         ISOLATION_ID: ${ISOLATION_ID}
+    tty: true
+    stdin_open: true
     image: sawtooth-seth-tp:${ISOLATION_ID}
     container_name: seth-tp
     volumes:

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -73,6 +73,8 @@ services:
         - http_proxy
         - https_proxy
         - no_proxy
+    tty: true
+    stdin_open: true
     image: sawtooth-seth-tp:${ISOLATION_ID}
     container_name: seth-tp
     depends_on:


### PR DESCRIPTION
Newer Dockerfiles contain git clones, which can hang without a tty/stdin available.  Not sure why this doesn't show on hyperledger jenkins, but it doubtless appears in other environments than our own. 

Signed-off-by: Kevin O'Donnell <kodonnel@gmail.com>