### PR TITLE
Fix Seth for apt-key/gpg Proxy on Bionic

### DIFF
--- a/ci/sawtooth-seth-cli
+++ b/ci/sawtooth-seth-cli
@@ -20,13 +20,13 @@
 FROM ubuntu:xenial
 
 RUN apt-get update \
- && apt-get install gnupg -y
+ && apt-get install curl gnupg -y
 
 LABEL "install-type"="repo"
 
 RUN echo "deb [arch=amd64] http://repo.sawtooth.me/ubuntu/bumper/stable xenial universe" >> /etc/apt/sources.list \
- && (apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 8AA7AF1F1091A5FD \
- || apt-key adv --keyserver hkp://p80.pool.sks-keyservers.net:80 --recv-keys 8AA7AF1F1091A5FD) \
+ && (curl -sSL 'http://keyserver.ubuntu.com/pks/lookup?op=get&search=0x8AA7AF1F1091A5FD' | apt-key add - \
+ || curl -sSL 'http://p80.pool.sks-keyservers.net/pks/lookup?op=get&search=0x8AA7AF1F1091A5FD' | apt-key add - ) \
  && apt-get update \
  && apt-get install -y -q \
     sawtooth-seth-cli \

--- a/ci/sawtooth-seth-cli-go
+++ b/ci/sawtooth-seth-cli-go
@@ -20,13 +20,13 @@
 FROM ubuntu:xenial
 
 RUN apt-get update \
- && apt-get install gnupg -y
+ && apt-get install curl gnupg -y
 
 LABEL "install-type"="repo"
 
 RUN echo "deb [arch=amd64] http://repo.sawtooth.me/ubuntu/bumper/stable xenial universe" >> /etc/apt/sources.list \
- && (apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 8AA7AF1F1091A5FD \
- || apt-key adv --keyserver hkp://p80.pool.sks-keyservers.net:80 --recv-keys 8AA7AF1F1091A5FD) \
+ && (curl -sSL 'http://keyserver.ubuntu.com/pks/lookup?op=get&search=0x8AA7AF1F1091A5FD' | apt-key add - \
+ || curl -sSL 'http://p80.pool.sks-keyservers.net/pks/lookup?op=get&search=0x8AA7AF1F1091A5FD' | apt-key add - ) \
  && apt-get update \
  && apt-get install -y -q \
     sawtooth-seth-cli-go \

--- a/ci/sawtooth-seth-rpc
+++ b/ci/sawtooth-seth-rpc
@@ -20,13 +20,13 @@
 FROM ubuntu:xenial
 
 RUN apt-get update \
- && apt-get install gnupg -y
+ && apt-get install curl gnupg -y
 
 LABEL "install-type"="repo"
 
 RUN echo "deb [arch=amd64] http://repo.sawtooth.me/ubuntu/bumper/stable xenial universe" >> /etc/apt/sources.list \
- && (apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 8AA7AF1F1091A5FD \
- || apt-key adv --keyserver hkp://p80.pool.sks-keyservers.net:80 --recv-keys 8AA7AF1F1091A5FD) \
+ && (curl -sSL 'http://keyserver.ubuntu.com/pks/lookup?op=get&search=0x8AA7AF1F1091A5FD' | apt-key add - \
+ || curl -sSL 'http://p80.pool.sks-keyservers.net/pks/lookup?op=get&search=0x8AA7AF1F1091A5FD' | apt-key add - ) \
  && apt-get update \
  && apt-get install -y -q \
     sawtooth-seth-rpc \

--- a/ci/sawtooth-seth-tp
+++ b/ci/sawtooth-seth-tp
@@ -20,13 +20,13 @@
 FROM ubuntu:xenial
 
 RUN apt-get update \
- && apt-get install gnupg -y
+ && apt-get install curl gnupg -y
 
 LABEL "install-type"="repo"
 
 RUN echo "deb [arch=amd64] http://repo.sawtooth.me/ubuntu/bumper/stable xenial universe" >> /etc/apt/sources.list \
- && (apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 8AA7AF1F1091A5FD \
- || apt-key adv --keyserver hkp://p80.pool.sks-keyservers.net:80 --recv-keys 8AA7AF1F1091A5FD) \
+ && (curl -sSL 'http://keyserver.ubuntu.com/pks/lookup?op=get&search=0x8AA7AF1F1091A5FD' | apt-key add - \
+ || curl -sSL 'http://p80.pool.sks-keyservers.net/pks/lookup?op=get&search=0x8AA7AF1F1091A5FD' | apt-key add - ) \
  && apt-get update \
  && apt-get install -y -q \
     sawtooth-seth-tp \

--- a/cli-go/Dockerfile
+++ b/cli-go/Dockerfile
@@ -16,7 +16,7 @@
 FROM ubuntu:bionic
 
 RUN apt-get update \
- && apt-get install gnupg -y
+ && apt-get install curl gnupg -y
 
 ENV GOPATH=/project/sawtooth-seth/cli-go
 ENV PATH=$PATH:/project/sawtooth-seth/cli-go/bin:/project/sawtooth-seth/bin:/usr/lib/go-1.10/bin
@@ -29,10 +29,10 @@ RUN \
   https_proxy=$HTTPS_PROXY; \
  fi
 
-RUN (apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 44FC67F19B2466EA \
- || apt-key adv --keyserver hkp://p80.pool.sks-keyservers.net:80 --recv-keys 44FC67F19B2466EA) \
- && (apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 308C15A29AD198E9 \
- || apt-key adv --keyserver hkp://p80.pool.sks-keyservers.net:80 --recv-keys 308C15A29AD198E9) \
+RUN (curl -sSL 'http://keyserver.ubuntu.com/pks/lookup?op=get&search=0x44FC67F19B2466EA' | apt-key add - \
+ || curl -sSL 'http://p80.pool.sks-keyservers.net/pks/lookup?op=get&search=0x44FC67F19B2466EA' | apt-key add - ) \
+ && (curl -sSL 'http://keyserver.ubuntu.com/pks/lookup?op=get&search=0x308C15A29AD198E9' | apt-key add - \
+ || curl -sSL 'http://p80.pool.sks-keyservers.net/pks/lookup?op=get&search=0x308C15A29AD198E9' | apt-key add - ) \
  && echo 'deb http://repo.sawtooth.me/ubuntu/nightly bionic universe' >> /etc/apt/sources.list \
  && echo 'deb http://ppa.launchpad.net/gophers/archive/ubuntu bionic main' >> /etc/apt/sources.list \
  && apt-get update \

--- a/cli-go/Dockerfile-installed-bionic
+++ b/cli-go/Dockerfile-installed-bionic
@@ -18,15 +18,15 @@
 FROM ubuntu:bionic
 
 RUN apt-get update \
- && apt-get install gnupg -y
+ && apt-get install curl gnupg -y
 
 ENV GOPATH=/project/sawtooth-seth/cli-go
 ENV PATH=$PATH:/project/sawtooth-seth/cli-go/bin:/project/sawtooth-seth/bin:/usr/lib/go-1.10/bin
 
-RUN (apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 44FC67F19B2466EA \
- || apt-key adv --keyserver hkp://p80.pool.sks-keyservers.net:80 --recv-keys 44FC67F19B2466EA) \
- && (apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 308C15A29AD198E9 \
- || apt-key adv --keyserver hkp://p80.pool.sks-keyservers.net:80 --recv-keys 308C15A29AD198E9) \
+RUN (curl -sSL 'http://keyserver.ubuntu.com/pks/lookup?op=get&search=0x44FC67F19B2466EA' | apt-key add - \
+ || curl -sSL 'http://p80.pool.sks-keyservers.net/pks/lookup?op=get&search=0x44FC67F19B2466EA' | apt-key add - ) \
+ && (curl -sSL 'http://keyserver.ubuntu.com/pks/lookup?op=get&search=0x308C15A29AD198E9' | apt-key add - \
+ || curl -sSL 'http://p80.pool.sks-keyservers.net/pks/lookup?op=get&search=0x308C15A29AD198E9' | apt-key add - ) \
  && echo 'deb http://repo.sawtooth.me/ubuntu/nightly bionic universe' >> /etc/apt/sources.list \
  && echo 'deb http://ppa.launchpad.net/gophers/archive/ubuntu bionic main' >> /etc/apt/sources.list \
  && apt-get update \
@@ -107,7 +107,7 @@ RUN pkg_dir=/project/build/debs/ \
 FROM ubuntu:bionic
 
 RUN apt-get update \
- && apt-get install gnupg -y
+ && apt-get install curl gnupg -y
 
 RUN mkdir /debs
 

--- a/cli-go/Dockerfile-installed-xenial
+++ b/cli-go/Dockerfile-installed-xenial
@@ -18,8 +18,10 @@ FROM ubuntu:xenial
 ENV GOPATH=/project/sawtooth-seth/cli-go
 ENV PATH=$PATH:/project/sawtooth-seth/cli-go/bin:/project/sawtooth-seth/bin:/usr/lib/go-1.10/bin
 
-RUN (apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 8AA7AF1F1091A5FD 9AD198E9 \
- || apt-key adv --keyserver hkp://p80.pool.sks-keyservers.net:80 --recv-keys 8AA7AF1F1091A5FD 9AD198E9) \
+RUN (curl -sSL 'http://keyserver.ubuntu.com/pks/lookup?op=get&search=0x8AA7AF1F1091A5FD' | apt-key add - \
+ || curl -sSL 'http://p80.pool.sks-keyservers.net/pks/lookup?op=get&search=0x8AA7AF1F1091A5FD' | apt-key add - ) \
+ && (curl -sSL 'http://keyserver.ubuntu.com/pks/lookup?op=get&search=0x9AD198E9' | apt-key add - \
+ || curl -sSL 'http://p80.pool.sks-keyservers.net/pks/lookup?op=get&search=0x9AD198E9' | apt-key add - ) \
  && echo 'deb http://repo.sawtooth.me/ubuntu/bumper/stable xenial universe' >> /etc/apt/sources.list \
  && echo 'deb http://ppa.launchpad.net/gophers/archive/ubuntu xenial main' >> /etc/apt/sources.list \
  && apt-get update \

--- a/cli/Dockerfile
+++ b/cli/Dockerfile
@@ -16,10 +16,10 @@
 FROM ubuntu:bionic
 
 RUN apt-get update \
- && apt-get install gnupg -y
+ && apt-get install curl gnupg -y
 
-RUN (apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 44FC67F19B2466EA \
- || apt-key adv --keyserver hkp://p80.pool.sks-keyservers.net:80 --recv-keys 44FC67F19B2466EA) \
+RUN (curl -sSL 'http://keyserver.ubuntu.com/pks/lookup?op=get&search=0x44FC67F19B2466EA' | apt-key add - \
+ || curl -sSL 'http://p80.pool.sks-keyservers.net/pks/lookup?op=get&search=0x44FC67F19B2466EA' | apt-key add - ) \
  && echo 'deb http://repo.sawtooth.me/ubuntu/nightly bionic universe' >> /etc/apt/sources.list \
  && apt-get update \
  && apt-get install -y -q \

--- a/cli/Dockerfile-installed-bionic
+++ b/cli/Dockerfile-installed-bionic
@@ -18,10 +18,10 @@
 FROM ubuntu:bionic
 
 RUN apt-get update \
- && apt-get install gnupg -y
+ && apt-get install curl gnupg -y
 
-RUN (apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 44FC67F19B2466EA \
- || apt-key adv --keyserver hkp://p80.pool.sks-keyservers.net:80 --recv-keys 44FC67F19B2466EA) \
+RUN (curl -sSL 'http://keyserver.ubuntu.com/pks/lookup?op=get&search=0x44FC67F19B2466EA' | apt-key add - \
+ || curl -sSL 'http://p80.pool.sks-keyservers.net/pks/lookup?op=get&search=0x44FC67F19B2466EA' | apt-key add - ) \
  && echo 'deb http://repo.sawtooth.me/ubuntu/nightly bionic universe' >> /etc/apt/sources.list \
  && apt-get update \
  && apt-get install -y -q \

--- a/cli/Dockerfile-installed-xenial
+++ b/cli/Dockerfile-installed-xenial
@@ -15,8 +15,8 @@
 
 FROM ubuntu:xenial
 
-RUN (apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 8AA7AF1F1091A5FD \
- || apt-key adv --keyserver hkp://p80.pool.sks-keyservers.net:80 --recv-keys 8AA7AF1F1091A5FD) \
+RUN (curl -sSL 'http://keyserver.ubuntu.com/pks/lookup?op=get&search=0x8AA7AF1F1091A5FD' | apt-key add - \
+ || curl -sSL 'http://p80.pool.sks-keyservers.net/pks/lookup?op=get&search=0x8AA7AF1F1091A5FD' | apt-key add - ) \
  && echo 'deb http://repo.sawtooth.me/ubuntu/bumper/stable xenial universe' >> /etc/apt/sources.list \
  && apt-get update \
  && apt-get install -y -q \

--- a/docs/Dockerfile
+++ b/docs/Dockerfile
@@ -29,14 +29,14 @@
 FROM ubuntu:bionic
 
 RUN apt-get update \
- && apt-get install gnupg -y
+ && apt-get install curl gnupg -y
 
 ENV DEBIAN_FRONTEND=noninteractive
 
-RUN (apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 44FC67F19B2466EA \
- || apt-key adv --keyserver hkp://p80.pool.sks-keyservers.net:80 --recv-keys 44FC67F19B2466EA) \
- && (apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 308C15A29AD198E9 \
- || apt-key adv --keyserver hkp://p80.pool.sks-keyservers.net:80 --recv-keys 308C15A29AD198E9) \
+RUN (curl -sSL 'http://keyserver.ubuntu.com/pks/lookup?op=get&search=0x44FC67F19B2466EA' | apt-key add - \
+ || curl -sSL 'http://p80.pool.sks-keyservers.net/pks/lookup?op=get&search=0x44FC67F19B2466EA' | apt-key add - ) \
+ && (curl -sSL 'http://keyserver.ubuntu.com/pks/lookup?op=get&search=0x308C15A29AD198E9' | apt-key add - \
+ || curl -sSL 'http://p80.pool.sks-keyservers.net/pks/lookup?op=get&search=0x308C15A29AD198E9' | apt-key add - ) \
  && echo 'deb http://repo.sawtooth.me/ubuntu/nightly bionic universe' >> /etc/apt/sources.list \
  && echo 'deb http://ppa.launchpad.net/gophers/archive/ubuntu bionic main' >> /etc/apt/sources.list \
  && apt-get update \

--- a/processor/Dockerfile
+++ b/processor/Dockerfile
@@ -16,24 +16,16 @@
 FROM ubuntu:bionic
 
 RUN apt-get update \
- && apt-get install gnupg -y
+ && apt-get install curl gnupg -y
 
 ENV GOPATH=/project/sawtooth-seth/processor
 ENV PATH=$PATH:/project/sawtooth-seth/processor/bin:/project/sawtooth-seth/bin:/usr/lib/go-1.10/bin
 WORKDIR $GOPATH/src/seth_tp
 
-RUN \
- if [ ! -z $HTTP_PROXY ] && [ -z $http_proxy ]; then \
-  http_proxy=$HTTP_PROXY; \
- fi; \
- if [ ! -z $HTTPS_PROXY ] && [ -z $https_proxy ]; then \
-  https_proxy=$HTTPS_PROXY; \
- fi
-
-RUN (apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 44FC67F19B2466EA \
- || apt-key adv --keyserver hkp://p80.pool.sks-keyservers.net:80 --recv-keys 44FC67F19B2466EA) \
- && (apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 308C15A29AD198E9 \
- || apt-key adv --keyserver hkp://p80.pool.sks-keyservers.net:80 --recv-keys 308C15A29AD198E9) \
+RUN (curl -sSL 'http://keyserver.ubuntu.com/pks/lookup?op=get&search=0x44FC67F19B2466EA' | apt-key add - \
+ || curl -sSL 'http://p80.pool.sks-keyservers.net/pks/lookup?op=get&search=0x44FC67F19B2466EA' | apt-key add - ) \
+ && (curl -sSL 'http://keyserver.ubuntu.com/pks/lookup?op=get&search=0x308C15A29AD198E9' | apt-key add - \
+ || curl -sSL 'http://p80.pool.sks-keyservers.net/pks/lookup?op=get&search=0x308C15A29AD198E9' | apt-key add - ) \
  && echo 'deb http://repo.sawtooth.me/ubuntu/nightly bionic universe' >> /etc/apt/sources.list \
  && echo 'deb http://ppa.launchpad.net/gophers/archive/ubuntu bionic main' >> /etc/apt/sources.list \
  && apt-get update \
@@ -47,14 +39,6 @@ RUN (apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 44FC67F19
     python3-grpcio-tools \
  && apt-get clean \
  && rm -rf /var/lib/apt/lists/*
-
-RUN \
- if [ ! -z $http_proxy ]; then \
-  git config --global http.proxy $http_proxy; \
- fi; \
- if [ ! -z $https_proxy ]; then \
-  git config --global https.proxy $https_proxy; \
- fi
 
 RUN git config --global url."https://".insteadOf git://
 

--- a/processor/Dockerfile-installed-bionic
+++ b/processor/Dockerfile-installed-bionic
@@ -18,16 +18,16 @@
 FROM ubuntu:bionic
 
 RUN apt-get update \
- && apt-get install gnupg -y
+ && apt-get install curl gnupg -y
 
 ENV GOPATH=/project/sawtooth-seth/processor
 ENV PATH=$PATH:/project/sawtooth-seth/processor/bin:/project/sawtooth-seth/bin:/usr/lib/go-1.10/bin
 WORKDIR $GOPATH/src/seth_tp
 
-RUN (apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 44FC67F19B2466EA \
- || apt-key adv --keyserver hkp://p80.pool.sks-keyservers.net:80 --recv-keys 44FC67F19B2466EA) \
- && (apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 308C15A29AD198E9 \
- || apt-key adv --keyserver hkp://p80.pool.sks-keyservers.net:80 --recv-keys 308C15A29AD198E9) \
+RUN (curl -sSL 'http://keyserver.ubuntu.com/pks/lookup?op=get&search=0x44FC67F19B2466EA' | apt-key add - \
+ || curl -sSL 'http://p80.pool.sks-keyservers.net/pks/lookup?op=get&search=0x44FC67F19B2466EA' | apt-key add - ) \
+ && (curl -sSL 'http://keyserver.ubuntu.com/pks/lookup?op=get&search=0x308C15A29AD198E9' | apt-key add - \
+ || curl -sSL 'http://p80.pool.sks-keyservers.net/pks/lookup?op=get&search=0x308C15A29AD198E9' | apt-key add - ) \
  && echo 'deb http://repo.sawtooth.me/ubuntu/nightly bionic universe' >> /etc/apt/sources.list \
  && echo 'deb http://ppa.launchpad.net/gophers/archive/ubuntu bionic main' >> /etc/apt/sources.list \
  && apt-get update \

--- a/processor/Dockerfile-installed-xenial
+++ b/processor/Dockerfile-installed-xenial
@@ -19,8 +19,10 @@ ENV GOPATH=/project/sawtooth-seth/processor
 ENV PATH=$PATH:/project/sawtooth-seth/processor/bin:/project/sawtooth-seth/bin:/usr/lib/go-1.10/bin
 WORKDIR $GOPATH/src/seth_tp
 
-RUN (apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 8AA7AF1F1091A5FD 9AD198E9 \
- || apt-key adv --keyserver hkp://p80.pool.sks-keyservers.net:80 --recv-keys 8AA7AF1F1091A5FD 9AD198E9) \
+RUN (curl -sSL 'http://keyserver.ubuntu.com/pks/lookup?op=get&search=0x8AA7AF1F1091A5FD' | apt-key add - \
+ || curl -sSL 'http://p80.pool.sks-keyservers.net/pks/lookup?op=get&search=0x8AA7AF1F1091A5FD' | apt-key add - ) \
+ && (curl -sSL 'http://keyserver.ubuntu.com/pks/lookup?op=get&search=0x9AD198E9' | apt-key add - \
+ || curl -sSL 'http://p80.pool.sks-keyservers.net/pks/lookup?op=get&search=0x9AD198E9' | apt-key add - ) \
  && echo 'deb http://repo.sawtooth.me/ubuntu/bumper/stable xenial universe' >> /etc/apt/sources.list \
  && echo 'deb http://ppa.launchpad.net/gophers/archive/ubuntu xenial main' >> /etc/apt/sources.list \
  && apt-get update \

--- a/rpc/Dockerfile
+++ b/rpc/Dockerfile
@@ -16,10 +16,10 @@
 FROM ubuntu:bionic
 
 RUN apt-get update \
- && apt-get install gnupg -y
+ && apt-get install curl gnupg -y
 
-RUN (apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 44FC67F19B2466EA \
- || apt-key adv --keyserver hkp://p80.pool.sks-keyservers.net:80 --recv-keys 44FC67F19B2466EA) \
+RUN (curl -sSL 'http://keyserver.ubuntu.com/pks/lookup?op=get&search=0x44FC67F19B2466EA' | apt-key add - \
+ || curl -sSL 'http://p80.pool.sks-keyservers.net/pks/lookup?op=get&search=0x44FC67F19B2466EA' | apt-key add - ) \
  && echo 'deb http://repo.sawtooth.me/ubuntu/nightly bionic universe' >> /etc/apt/sources.list \
  && apt-get update \
  && apt-get install -y -q \

--- a/rpc/Dockerfile-installed-bionic
+++ b/rpc/Dockerfile-installed-bionic
@@ -18,10 +18,10 @@
 FROM ubuntu:bionic
 
 RUN apt-get update \
- && apt-get install gnupg -y
+ && apt-get install curl gnupg -y
 
-RUN (apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 44FC67F19B2466EA \
- || apt-key adv --keyserver hkp://p80.pool.sks-keyservers.net:80 --recv-keys 44FC67F19B2466EA) \
+RUN (curl -sSL 'http://keyserver.ubuntu.com/pks/lookup?op=get&search=0x44FC67F19B2466EA' | apt-key add - \
+ || curl -sSL 'http://p80.pool.sks-keyservers.net/pks/lookup?op=get&search=0x44FC67F19B2466EA' | apt-key add - ) \
  && echo 'deb http://repo.sawtooth.me/ubuntu/nightly bionic universe' >> /etc/apt/sources.list \
  && apt-get update \
  && apt-get install -y -q \

--- a/rpc/Dockerfile-installed-xenial
+++ b/rpc/Dockerfile-installed-xenial
@@ -15,8 +15,8 @@
 
 FROM ubuntu:xenial
 
-RUN (apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 8AA7AF1F1091A5FD \
- || apt-key adv --keyserver hkp://p80.pool.sks-keyservers.net:80 --recv-keys 8AA7AF1F1091A5FD) \
+RUN (curl -sSL 'http://keyserver.ubuntu.com/pks/lookup?op=get&search=0x8AA7AF1F1091A5FD' | apt-key add - \
+ || curl -sSL 'http://p80.pool.sks-keyservers.net/pks/lookup?op=get&search=0x8AA7AF1F1091A5FD' | apt-key add - ) \
  && echo 'deb http://repo.sawtooth.me/ubuntu/bumper/stable xenial universe' >> /etc/apt/sources.list \
  && apt-get update \
  && apt-get install -y -q \


### PR DESCRIPTION
gpg (through "apt-key adv") ignores http_proxy and
https_proxy settings on Bionic.
The solution is to use http with curl instead to download keys.

Signed-off-by: danintel <daniel.anderson@intel.com>