### PR TITLE
Fix Seth for Sawtooth 1.1 Consensus

### DIFF
--- a/docker-compose-installed.yaml
+++ b/docker-compose-installed.yaml
@@ -137,7 +137,8 @@ services:
         sawtooth-validator -vv \
             --endpoint tcp://validator:8800 \
             --bind component:tcp://eth0:4004 \
-            --bind network:tcp://eth0:8800
+            --bind network:tcp://eth0:8800 \
+            --bind consensus:tcp://eth0:5050
       "
 
   seth-rpc:

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -142,7 +142,8 @@ services:
         sawtooth-validator -vv \
             --endpoint tcp://validator:8800 \
             --bind component:tcp://eth0:4004 \
-            --bind network:tcp://eth0:8800
+            --bind network:tcp://eth0:8800 \
+            --bind consensus:tcp://eth0:5050
       "
 
   seth-rpc:


### PR DESCRIPTION
Sawtooth 1.1 Consensus does not work.
The DevMode consensus engine times-out and does not connect
to the validator and times-out.
The solution is to open port 5050 in container devmode-engine-rust.

Signed-off-by: danintel <daniel.anderson@intel.com>