### PR TITLE
Remove setting sawtooth.validator.batch_injectors

### DIFF
--- a/docker-compose-installed.yaml
+++ b/docker-compose-installed.yaml
@@ -130,7 +130,6 @@ services:
           -k /etc/sawtooth/keys/validator.priv \
           sawtooth.consensus.algorithm.name=Devmode \
           sawtooth.consensus.algorithm.version=0.1 \
-          sawtooth.validator.batch_injectors=block_info \
           -o config.batch &&
         sawadm genesis config-genesis.batch config.batch
         fi;

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -135,7 +135,6 @@ services:
           -k /etc/sawtooth/keys/validator.priv \
           sawtooth.consensus.algorithm.name=Devmode \
           sawtooth.consensus.algorithm.version=0.1 \
-          sawtooth.validator.batch_injectors=block_info \
           -o config.batch &&
         sawadm genesis config-genesis.batch config.batch
         fi;

--- a/integration/sawtooth_integration/docker/seth_blockhash_test.yaml
+++ b/integration/sawtooth_integration/docker/seth_blockhash_test.yaml
@@ -69,7 +69,6 @@ services:
           -o config-genesis.batch &&
         sawset proposal create \
           -k /etc/sawtooth/keys/validator.priv \
-          sawtooth.validator.batch_injectors=block_info \
           -o config.batch &&
         sawadm genesis config-genesis.batch config.batch
         fi;

--- a/integration/sawtooth_integration/docker/seth_blocknum_test.yaml
+++ b/integration/sawtooth_integration/docker/seth_blocknum_test.yaml
@@ -69,7 +69,6 @@ services:
           -o config-genesis.batch &&
         sawset proposal create \
           -k /etc/sawtooth/keys/validator.priv \
-          sawtooth.validator.batch_injectors=block_info \
           -o config.batch &&
         sawadm genesis config-genesis.batch config.batch
         fi;

--- a/integration/sawtooth_integration/docker/seth_chaining_test.yaml
+++ b/integration/sawtooth_integration/docker/seth_chaining_test.yaml
@@ -69,7 +69,6 @@ services:
           -o config-genesis.batch &&
         sawset proposal create \
           -k /etc/sawtooth/keys/validator.priv \
-          sawtooth.validator.batch_injectors=block_info \
           -o config.batch &&
         sawadm genesis config-genesis.batch config.batch
         fi;

--- a/integration/sawtooth_integration/docker/seth_client_test.yaml
+++ b/integration/sawtooth_integration/docker/seth_client_test.yaml
@@ -69,7 +69,6 @@ services:
           -o config-genesis.batch &&
         sawset proposal create \
           -k /etc/sawtooth/keys/validator.priv \
-          sawtooth.validator.batch_injectors=block_info \
           -o config.batch &&
         sawadm genesis config-genesis.batch config.batch
         fi;

--- a/integration/sawtooth_integration/docker/seth_intkey_test.yaml
+++ b/integration/sawtooth_integration/docker/seth_intkey_test.yaml
@@ -69,7 +69,6 @@ services:
           -o config-genesis.batch &&
         sawset proposal create \
           -k /etc/sawtooth/keys/validator.priv \
-          sawtooth.validator.batch_injectors=block_info \
           -o config.batch &&
         sawadm genesis config-genesis.batch config.batch
         fi;

--- a/integration/sawtooth_integration/docker/seth_perm_test.yaml
+++ b/integration/sawtooth_integration/docker/seth_perm_test.yaml
@@ -69,7 +69,6 @@ services:
           -o config-genesis.batch &&
         sawset proposal create \
           -k /etc/sawtooth/keys/validator.priv \
-          sawtooth.validator.batch_injectors=block_info \
           -o config.batch &&
         sawadm genesis config-genesis.batch config.batch
         fi;

--- a/integration/sawtooth_integration/docker/seth_timestamp_test.yaml
+++ b/integration/sawtooth_integration/docker/seth_timestamp_test.yaml
@@ -69,7 +69,6 @@ services:
           -o config-genesis.batch &&
         sawset proposal create \
           -k /etc/sawtooth/keys/validator.priv \
-          sawtooth.validator.batch_injectors=block_info \
           -o config.batch &&
         sawadm genesis config-genesis.batch config.batch
         fi;


### PR DESCRIPTION
Remove `sawtooth.validator.batch_injectors` setting from docker compose
files. This setting is deprecated.

Signed-off-by: Logan Seeley <seeley@bitwise.io>