### PR TITLE
Updated docker-compose.yaml to fix rpc bug

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -52,6 +52,7 @@ services:
     container_name: seth-cli-go
     volumes:
       - ./contracts:/project/sawtooth-seth/contracts
+      - sawtooth:/root/.sawtooth
     depends_on:
       - rest-api
     working_dir: /project/sawtooth-seth


### PR DESCRIPTION
In order to unlock accounts with Seth-rpc, the rpc service and the cli-go service need to share a volume where the aliases are stored. This PR introduces that volume.