### PR TITLE
Retire inactive Maintainers

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,1 @@
-*       @aludvik @grkvlt @dplumb94 @vaporos @peterschwarz @knkski
+*       @grkvlt @dplumb94 @vaporos @peterschwarz

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -1,8 +1,15 @@
+## Maintainers
+
+### Active Maintainers
 | Name | GitHub | RocketChat |
 | --- | --- | --- |
-| Adam Ludvik | aludvik | adamludvik |
 | Andrew Donald Kennedy | grkvlt | grkvlt |
 | Darian Plumb | dplumb94 | dplumb |
 | Shawn Amundson | vaporos | amundson |
 | Peter Schwarz | peterschwarz | pschwarz |
+
+### Retired Maintainers
+| Name | GitHub | RocketChat |
+| --- | --- | --- |
+| Adam Ludvik | aludvik | adamludvik |
 | Kenneth Koski | knkski | knkski |


### PR DESCRIPTION
Signed-off-by: Peter Schwarz <pschwarz@bitwise.io>