### PR TITLE
Fix versioning of packaged Rust components

### DIFF
--- a/cli/Dockerfile-installed-bionic
+++ b/cli/Dockerfile-installed-bionic
@@ -67,8 +67,9 @@ COPY . /project
 
 WORKDIR /project/cli
 
-RUN sed -i -e s/version.*$/version\ =\ \"$(../bin/get_version)\"/ Cargo.toml
-RUN /root/.cargo/bin/cargo deb
+RUN export VERSION=$(../bin/get_version) \
+ && sed -i -e s/version.*$/version\ =\ \"${VERSION}\"/ Cargo.toml \
+ && /root/.cargo/bin/cargo deb --deb-version $VERSION
 
 # -------------=== seth cli docker build ===-------------
 

--- a/rpc/Dockerfile-installed-bionic
+++ b/rpc/Dockerfile-installed-bionic
@@ -63,8 +63,9 @@ COPY . /project
 
 WORKDIR /project/rpc
 
-RUN sed -i -e "0,/version.*$/ s/version.*$/version\ =\ \"$(../bin/get_version)\"/" Cargo.toml
-RUN /root/.cargo/bin/cargo deb
+RUN export VERSION=$(../bin/get_version) \
+ && sed -i -e "0,/version.*$/ s/version.*$/version\ =\ \"${VERSION}\"/" Cargo.toml \
+ && /root/.cargo/bin/cargo deb --deb-version $VERSION
 
 # -------------=== seth rpc docker build ===-------------
 


### PR DESCRIPTION
The behavior of cargo-deb was changed to generate version numbers with
tildes instead of dashes. This is causing newly built packages to sort
below older releases.

https://github.com/mmstick/cargo-deb/pull/102

Signed-off-by: Richard Berg <rberg@bitwise.io>